### PR TITLE
Add Favorite Prompts feature

### DIFF
--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -12,6 +12,7 @@ from codebase_to_llm.domain.context_buffer import (
 
 from codebase_to_llm.domain.result import Result
 from codebase_to_llm.domain.rules import Rules
+from codebase_to_llm.domain.favorite_prompts import FavoritePrompts
 
 
 class ClipboardPort(Protocol):
@@ -91,3 +92,9 @@ class ContextBufferPort(Protocol):
     def clear(self) -> Result[None, str]: ...  # pragma: no cover
     def is_empty(self) -> bool: ...  # pragma: no cover
     def count_items(self) -> int: ...  # pragma: no cover
+
+class FavoritePromptsRepositoryPort(Protocol):
+    """Pure port for persisting favorite prompts."""
+
+    def load_prompts(self) -> Result[FavoritePrompts, str]: ...  # pragma: no cover
+    def save_prompts(self, prompts: FavoritePrompts) -> Result[None, str]: ...  # pragma: no cover

--- a/src/codebase_to_llm/domain/__init__.py
+++ b/src/codebase_to_llm/domain/__init__.py
@@ -1,0 +1,1 @@
+from .favorite_prompts import FavoritePrompt, FavoritePrompts

--- a/src/codebase_to_llm/domain/favorite_prompts.py
+++ b/src/codebase_to_llm/domain/favorite_prompts.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+from typing_extensions import final
+
+from .value_object import ValueObject
+from .result import Result, Ok, Err
+
+
+@final
+class FavoritePrompt:
+    """Single favorite prompt with a mandatory name and text."""
+
+    __slots__ = ("_name", "_content")
+
+    @staticmethod
+    def try_create(name: str, content: str) -> Result["FavoritePrompt", str]:
+        trimmed_name = name.strip()
+        if not trimmed_name:
+            return Err("Prompt name cannot be empty.")
+        return Ok(FavoritePrompt(trimmed_name, content))
+
+    def __init__(self, name: str, content: str) -> None:
+        self._name = name
+        self._content = content
+
+    def name(self) -> str:
+        return self._name
+
+    def content(self) -> str:
+        return self._content
+
+
+@final
+class FavoritePrompts(ValueObject):
+    """Immutable collection of :class:`FavoritePrompt` objects."""
+
+    __slots__ = ("_prompts",)
+    _prompts: Tuple[FavoritePrompt, ...]
+
+    @staticmethod
+    def try_create(prompts: Iterable[FavoritePrompt]) -> Result["FavoritePrompts", str]:
+        return Ok(FavoritePrompts(tuple(prompts)))
+
+    def __init__(self, prompts: Tuple[FavoritePrompt, ...]):
+        self._prompts = prompts
+
+    def prompts(self) -> Tuple[FavoritePrompt, ...]:  # noqa: D401
+        return self._prompts
+
+    def remove_prompt(self, name: str) -> "FavoritePrompts":
+        new_prompts = tuple(p for p in self._prompts if p.name() != name)
+        return FavoritePrompts(new_prompts)
+

--- a/src/codebase_to_llm/infrastructure/__init__.py
+++ b/src/codebase_to_llm/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+from .filesystem_favorite_prompts_repository import FavoritePromptsRepository

--- a/src/codebase_to_llm/infrastructure/filesystem_favorite_prompts_repository.py
+++ b/src/codebase_to_llm/infrastructure/filesystem_favorite_prompts_repository.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+import json
+
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.application.ports import FavoritePromptsRepositoryPort
+from codebase_to_llm.domain.favorite_prompts import FavoritePrompt, FavoritePrompts
+
+
+class FavoritePromptsRepository(FavoritePromptsRepositoryPort):
+    """Reads / writes the favorite prompts in the user’s home directory."""
+
+    __slots__ = ("_path", "_prompts")
+
+    def __init__(self, path: Path | None = None) -> None:
+        default_path = Path.home() / ".copy_to_llm" / "favorite_prompts"
+        self._path: Final = path or default_path
+        self._prompts: FavoritePrompts | None = None
+
+    def load_prompts(self) -> Result[FavoritePrompts, str]:
+        try:
+            if not self._path.exists():
+                return Err("Favorite prompts file not found.")
+            raw = self._path.read_text(encoding="utf-8", errors="ignore")
+            data = json.loads(raw) if raw.strip() else []
+            prompts: list[FavoritePrompt] = []
+            if isinstance(data, list):
+                for item in data:
+                    if isinstance(item, dict):
+                        name = str(item.get("name", ""))
+                        content_raw = item.get("content")
+                        content = str(content_raw) if content_raw is not None else ""
+                        prompt_result = FavoritePrompt.try_create(name, content)
+                        if prompt_result.is_err():
+                            return Err(prompt_result.err() or "")
+                        prompt = prompt_result.ok()
+                        assert prompt is not None
+                        prompts.append(prompt)
+            prompts_result = FavoritePrompts.try_create(prompts)
+            if prompts_result.is_err():
+                return Err(prompts_result.err() or "")
+            prompts_value = prompts_result.ok()
+            assert prompts_value is not None
+            self._prompts = prompts_value
+            return Ok(prompts_value)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+
+    def save_prompts(self, prompts: FavoritePrompts) -> Result[None, str]:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            data = [
+                {"name": p.name(), "content": p.content()} for p in prompts.prompts()
+            ]
+            self._path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            return Ok(None)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+

--- a/src/codebase_to_llm/interface/__init__.py
+++ b/src/codebase_to_llm/interface/__init__.py
@@ -1,0 +1,1 @@
+from .prompts_dialogs import PromptsManagerDialog

--- a/src/codebase_to_llm/interface/prompts_dialogs.py
+++ b/src/codebase_to_llm/interface/prompts_dialogs.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from typing import List
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMessageBox,
+    QPushButton,
+    QPlainTextEdit,
+    QVBoxLayout,
+    QAbstractItemView,
+)
+
+from codebase_to_llm.domain.favorite_prompts import FavoritePrompt, FavoritePrompts
+from codebase_to_llm.infrastructure.filesystem_favorite_prompts_repository import (
+    FavoritePromptsRepository,
+)
+
+
+class PromptDialogForm(QDialog):
+    """Dialog to edit a single prompt."""
+
+    def __init__(self, current_content: str, repo: FavoritePromptsRepository, name: str = "") -> None:
+        super().__init__()
+        self.setWindowTitle("Edit Prompt")
+        self._repo = repo
+        layout = QVBoxLayout(self)
+
+        name_layout = QHBoxLayout()
+        name_label = QLabel("Name:")
+        self._name_edit = QLineEdit()
+        self._name_edit.setText(name)
+        name_layout.addWidget(name_label)
+        name_layout.addWidget(self._name_edit)
+        layout.addLayout(name_layout)
+
+        self._edit = QPlainTextEdit()
+        self._edit.setPlainText(current_content)
+        layout.addWidget(self._edit)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.button(QDialogButtonBox.StandardButton.Save).setText("Save")
+        buttons.button(QDialogButtonBox.StandardButton.Cancel).setText("Cancel")
+        buttons.accepted.connect(self.accept)  # type: ignore[arg-type]
+        buttons.rejected.connect(self.reject)  # type: ignore[arg-type]
+        layout.addWidget(buttons)
+
+    def text(self) -> str:
+        return self._edit.toPlainText()
+
+    def name(self) -> str:
+        return self._name_edit.text()
+
+
+class PromptsManagerDialog(QDialog):
+    """Dialog to manage all favorite prompts."""
+
+    def __init__(self, repo: FavoritePromptsRepository) -> None:
+        super().__init__()
+        self.setWindowTitle("Manage Favorite Prompts")
+        self._repo = repo
+        self._selected_index: int | None = None
+        self._prompts: List[FavoritePrompt] = []
+
+        layout = QHBoxLayout(self)
+
+        self._list_widget = QListWidget()
+        self._list_widget.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self._list_widget.currentRowChanged.connect(self._on_selected)
+        layout.addWidget(self._list_widget, 1)
+
+        button_layout = QVBoxLayout()
+        self._new_btn = QPushButton("New Prompt")
+        self._delete_btn = QPushButton("Delete Prompt")
+        self._modify_btn = QPushButton("Modify Prompt")
+        self._new_btn.clicked.connect(self._on_new)
+        self._delete_btn.clicked.connect(self._on_delete)
+        self._modify_btn.clicked.connect(self._on_modify)
+        button_layout.addWidget(self._new_btn)
+        button_layout.addWidget(self._delete_btn)
+        button_layout.addWidget(self._modify_btn)
+        button_layout.addStretch(1)
+        layout.addLayout(button_layout)
+
+        self._load_prompts()
+
+    def _load_prompts(self) -> None:
+        result = self._repo.load_prompts()
+        if result.is_ok():
+            val = result.ok()
+            assert val is not None
+            self._prompts = list(val.prompts())
+        else:
+            self._prompts = []
+        self._refresh_list()
+        if self._prompts:
+            self._list_widget.setCurrentRow(0)
+
+    def _refresh_list(self) -> None:
+        self._list_widget.clear()
+        for prompt in self._prompts:
+            self._list_widget.addItem(prompt.name())
+
+    def _on_selected(self, idx: int) -> None:
+        self._selected_index = idx if 0 <= idx < len(self._prompts) else None
+
+    def _on_new(self) -> None:
+        dialog = PromptDialogForm("", self._repo, name="")
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            name = dialog.name().strip()
+            content = dialog.text()
+            if not name:
+                QMessageBox.warning(self, "Validation Error", "Prompt name cannot be empty.")
+                return
+            result = FavoritePrompt.try_create(name, content)
+            if result.is_err():
+                QMessageBox.warning(self, "Validation Error", result.err() or "Invalid prompt.")
+                return
+            self._prompts.append(result.ok())
+            self._refresh_list()
+            self._list_widget.setCurrentRow(len(self._prompts) - 1)
+            prompts_obj = FavoritePrompts(tuple(self._prompts))
+            save_result = self._repo.save_prompts(prompts_obj)
+            if save_result.is_err():
+                QMessageBox.critical(self, "Save Error", save_result.err() or "Failed to save prompts.")
+
+    def _on_modify(self) -> None:
+        idx = self._selected_index
+        if idx is not None and 0 <= idx < len(self._prompts):
+            prompt = self._prompts[idx]
+            dialog = PromptDialogForm(prompt.content(), self._repo, name=prompt.name())
+            if dialog.exec() == QDialog.DialogCode.Accepted:
+                name = dialog.name().strip()
+                content = dialog.text()
+                if not name:
+                    QMessageBox.warning(self, "Validation Error", "Prompt name cannot be empty.")
+                    return
+                result = FavoritePrompt.try_create(name, content)
+                if result.is_err():
+                    QMessageBox.warning(self, "Validation Error", result.err() or "Invalid prompt.")
+                    return
+                self._prompts[idx] = result.ok()
+                self._refresh_list()
+                self._list_widget.setCurrentRow(idx)
+                prompts_obj = FavoritePrompts(tuple(self._prompts))
+                save_result = self._repo.save_prompts(prompts_obj)
+                if save_result.is_err():
+                    QMessageBox.critical(self, "Save Error", save_result.err() or "Failed to save prompts.")
+
+    def _on_delete(self) -> None:
+        idx = self._selected_index
+        if idx is not None and 0 <= idx < len(self._prompts):
+            del self._prompts[idx]
+            self._refresh_list()
+            self._selected_index = None
+            prompts_obj = FavoritePrompts(tuple(self._prompts))
+            save_result = self._repo.save_prompts(prompts_obj)
+            if save_result.is_err():
+                QMessageBox.critical(self, "Save Error", save_result.err() or "Failed to save prompts.")
+
+

--- a/src/codebase_to_llm/main.py
+++ b/src/codebase_to_llm/main.py
@@ -20,6 +20,9 @@ from codebase_to_llm.infrastructure.filesystem_recent_repository import (
     FileSystemRecentRepository,
 )
 from codebase_to_llm.infrastructure.filesystem_rules_repository import RulesRepository
+from codebase_to_llm.infrastructure.filesystem_favorite_prompts_repository import (
+    FavoritePromptsRepository,
+)
 from codebase_to_llm.infrastructure.in_memory_context_buffer_repository import (
     InMemoryContextBufferRepository,
 )
@@ -37,6 +40,7 @@ def main() -> None:  # noqa: D401 (simple verb)
     #
     repo: DirectoryRepositoryPort = FileSystemDirectoryRepository(root)
     rules_repo = RulesRepository()
+    prompts_repo = FavoritePromptsRepository()
     recent_repo = FileSystemRecentRepository()
     clipboard: ClipboardPort = QtClipboardService()
     context_buffer: ContextBufferPort = InMemoryContextBufferRepository()
@@ -46,6 +50,7 @@ def main() -> None:  # noqa: D401 (simple verb)
         clipboard,
         root,
         rules_repo,
+        prompts_repo,
         recent_repo,
         external_repo,
         context_buffer,


### PR DESCRIPTION
## Summary
- implement FavoritePrompt domain model
- persist favorite prompts on disk
- add dialogs to manage favorite prompts
- show favorite prompts in the user request context menu
- wire up repository and settings menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852e6e163548332a70395b92ad007ea