### PR TITLE
feat: manage favorite prompts through API and web UI

### DIFF
--- a/src/codebase_to_llm/application/uc_add_favorite_prompt.py
+++ b/src/codebase_to_llm/application/uc_add_favorite_prompt.py
@@ -1,0 +1,56 @@
+"""Use case for adding a favorite prompt."""
+
+from __future__ import annotations
+
+import uuid
+
+from codebase_to_llm.application.ports import FavoritePromptsRepositoryPort
+from codebase_to_llm.domain.favorite_prompts import (
+    FavoritePrompt,
+    FavoritePrompts,
+)
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class AddFavoritePromptUseCase:
+    """Adds a new favorite prompt and persists it."""
+
+    def __init__(self, repo: FavoritePromptsRepositoryPort):
+        self._repo = repo
+
+    def execute(self, name: str, content: str) -> Result[FavoritePrompt, str]:
+        new_id = str(uuid.uuid4())
+        prompt_result = FavoritePrompt.try_create(new_id, name, content)
+        if prompt_result.is_err():
+            return Err(prompt_result.err() or "Failed to create favorite prompt.")
+        prompt = prompt_result.ok()
+        if prompt is None:
+            return Err("Failed to create favorite prompt.")
+
+        load_result = self._repo.load_prompts()
+        if load_result.is_err():
+            empty_result = FavoritePrompts.try_create([])
+            if empty_result.is_err():
+                return Err(empty_result.err() or "Unknown error creating collection.")
+            prompts = empty_result.ok()
+        else:
+            prompts = load_result.ok()
+
+        if prompts is None:
+            empty_result = FavoritePrompts.try_create([])
+            if empty_result.is_err():
+                return Err(empty_result.err() or "Unknown error creating collection.")
+            prompts = empty_result.ok()
+
+        assert prompts is not None
+        add_result = prompts.add_prompt(prompt)
+        if add_result.is_err():
+            return Err(add_result.err() or "Failed to add favorite prompt.")
+        updated_prompts = add_result.ok()
+        assert updated_prompts is not None
+
+        save_result = self._repo.save_prompts(updated_prompts)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to save favorite prompts.")
+
+        return Ok(prompt)

--- a/src/codebase_to_llm/application/uc_get_favorite_prompt.py
+++ b/src/codebase_to_llm/application/uc_get_favorite_prompt.py
@@ -1,0 +1,35 @@
+"""Use case for retrieving a favorite prompt by id."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FavoritePromptsRepositoryPort
+from codebase_to_llm.domain.favorite_prompts import FavoritePrompt, FavoritePromptId
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class GetFavoritePromptUseCase:
+    """Returns a favorite prompt matching the given id."""
+
+    def __init__(self, repo: FavoritePromptsRepositoryPort):
+        self._repo = repo
+
+    def execute(self, id_value: str) -> Result[FavoritePrompt, str]:
+        id_result = FavoritePromptId.try_create(id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid id")
+        prompt_id = id_result.ok()
+        assert prompt_id is not None
+
+        load_result = self._repo.load_prompts()
+        if load_result.is_err():
+            return Err(load_result.err() or "Failed to load favorite prompts.")
+        prompts = load_result.ok()
+        if prompts is None:
+            return Err("Failed to load favorite prompts.")
+
+        find_result = prompts.find_prompt(prompt_id)
+        if find_result.is_err():
+            return Err(find_result.err() or "Favorite prompt not found.")
+        prompt = find_result.ok()
+        assert prompt is not None
+        return Ok(prompt)

--- a/src/codebase_to_llm/application/uc_get_favorite_prompts.py
+++ b/src/codebase_to_llm/application/uc_get_favorite_prompts.py
@@ -1,0 +1,32 @@
+"""Use case for retrieving all favorite prompts."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FavoritePromptsRepositoryPort
+from codebase_to_llm.domain.favorite_prompts import FavoritePrompts
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class GetFavoritePromptsUseCase:
+    """Loads favorite prompts from the repository."""
+
+    def __init__(self, repo: FavoritePromptsRepositoryPort):
+        self._repo = repo
+
+    def execute(self) -> Result[FavoritePrompts, str]:
+        load_result = self._repo.load_prompts()
+        if load_result.is_err():
+            empty_result = FavoritePrompts.try_create([])
+            if empty_result.is_err():
+                return Err(empty_result.err() or "Unknown error creating collection.")
+            prompts = empty_result.ok()
+            assert prompts is not None
+            return Ok(prompts)
+        prompts = load_result.ok()
+        if prompts is None:
+            empty_result = FavoritePrompts.try_create([])
+            if empty_result.is_err():
+                return Err(empty_result.err() or "Unknown error creating collection.")
+            prompts = empty_result.ok()
+        assert prompts is not None
+        return Ok(prompts)

--- a/src/codebase_to_llm/application/uc_remove_favorite_prompt.py
+++ b/src/codebase_to_llm/application/uc_remove_favorite_prompt.py
@@ -1,0 +1,40 @@
+"""Use case for removing a favorite prompt."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FavoritePromptsRepositoryPort
+from codebase_to_llm.domain.favorite_prompts import FavoritePromptId
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class RemoveFavoritePromptUseCase:
+    """Removes a favorite prompt identified by its id."""
+
+    def __init__(self, repo: FavoritePromptsRepositoryPort):
+        self._repo = repo
+
+    def execute(self, id_value: str) -> Result[None, str]:
+        id_result = FavoritePromptId.try_create(id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid id")
+        prompt_id = id_result.ok()
+        assert prompt_id is not None
+
+        load_result = self._repo.load_prompts()
+        if load_result.is_err():
+            return Err(load_result.err() or "Failed to load favorite prompts.")
+        prompts = load_result.ok()
+        if prompts is None:
+            return Err("Failed to load favorite prompts.")
+
+        remove_result = prompts.remove_prompt(prompt_id)
+        if remove_result.is_err():
+            return Err(remove_result.err() or "Failed to remove favorite prompt.")
+        updated_prompts = remove_result.ok()
+        assert updated_prompts is not None
+
+        save_result = self._repo.save_prompts(updated_prompts)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to save favorite prompts.")
+
+        return Ok(None)

--- a/src/codebase_to_llm/application/uc_update_favorite_prompt.py
+++ b/src/codebase_to_llm/application/uc_update_favorite_prompt.py
@@ -1,0 +1,43 @@
+"""Use case for updating an existing favorite prompt."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FavoritePromptsRepositoryPort
+from codebase_to_llm.domain.favorite_prompts import FavoritePrompt
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class UpdateFavoritePromptUseCase:
+    """Updates a favorite prompt identified by its id."""
+
+    def __init__(self, repo: FavoritePromptsRepositoryPort):
+        self._repo = repo
+
+    def execute(
+        self, id_value: str, name: str, content: str
+    ) -> Result[FavoritePrompt, str]:
+        prompt_result = FavoritePrompt.try_create(id_value, name, content)
+        if prompt_result.is_err():
+            return Err(prompt_result.err() or "Failed to create favorite prompt.")
+        prompt = prompt_result.ok()
+        if prompt is None:
+            return Err("Failed to create favorite prompt.")
+
+        load_result = self._repo.load_prompts()
+        if load_result.is_err():
+            return Err(load_result.err() or "Failed to load favorite prompts.")
+        prompts = load_result.ok()
+        if prompts is None:
+            return Err("Failed to load favorite prompts.")
+
+        update_result = prompts.update_prompt(prompt)
+        if update_result.is_err():
+            return Err(update_result.err() or "Failed to update favorite prompt.")
+        updated_prompts = update_result.ok()
+        assert updated_prompts is not None
+
+        save_result = self._repo.save_prompts(updated_prompts)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to save favorite prompts.")
+
+        return Ok(prompt)

--- a/src/codebase_to_llm/domain/favorite_prompts.py
+++ b/src/codebase_to_llm/domain/favorite_prompts.py
@@ -8,21 +8,53 @@ from .result import Result, Ok, Err
 
 
 @final
-class FavoritePrompt:
-    """Single favorite prompt with a mandatory name and text."""
+class FavoritePromptId(ValueObject):
+    """Unique identifier for a favorite prompt."""
 
-    __slots__ = ("_name", "_content")
+    __slots__ = ("_value",)
+    _value: str
 
     @staticmethod
-    def try_create(name: str, content: str) -> Result["FavoritePrompt", str]:
+    def try_create(value: str) -> Result["FavoritePromptId", str]:
+        trimmed_value = value.strip()
+        if not trimmed_value:
+            return Err("Favorite prompt id cannot be empty.")
+        return Ok(FavoritePromptId(trimmed_value))
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return self._value
+
+
+@final
+class FavoritePrompt:
+    """Single favorite prompt with a mandatory id, name and text."""
+
+    __slots__ = ("_id", "_name", "_content")
+
+    @staticmethod
+    def try_create(
+        id_value: str, name: str, content: str
+    ) -> Result["FavoritePrompt", str]:
+        id_result = FavoritePromptId.try_create(id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid id")
         trimmed_name = name.strip()
         if not trimmed_name:
             return Err("Prompt name cannot be empty.")
-        return Ok(FavoritePrompt(trimmed_name, content))
+        id_obj = id_result.ok()
+        assert id_obj is not None
+        return Ok(FavoritePrompt(id_obj, trimmed_name, content))
 
-    def __init__(self, name: str, content: str) -> None:
+    def __init__(self, id: FavoritePromptId, name: str, content: str) -> None:
+        self._id = id
         self._name = name
         self._content = content
+
+    def id(self) -> FavoritePromptId:
+        return self._id
 
     def name(self) -> str:
         return self._name
@@ -48,6 +80,41 @@ class FavoritePrompts(ValueObject):
     def prompts(self) -> Tuple[FavoritePrompt, ...]:  # noqa: D401
         return self._prompts
 
-    def remove_prompt(self, name: str) -> "FavoritePrompts":
-        new_prompts = tuple(p for p in self._prompts if p.name() != name)
-        return FavoritePrompts(new_prompts)
+    def add_prompt(self, prompt: FavoritePrompt) -> Result["FavoritePrompts", str]:
+        for existing in self._prompts:
+            if existing.id().value() == prompt.id().value():
+                return Err(f'Prompt with id "{prompt.id().value()}" already exists.')
+            if existing.name() == prompt.name():
+                return Err(f'Prompt with name "{prompt.name()}" already exists.')
+        return Ok(FavoritePrompts(self._prompts + (prompt,)))
+
+    def update_prompt(self, prompt: FavoritePrompt) -> Result["FavoritePrompts", str]:
+        new_prompts = []
+        found = False
+        for existing in self._prompts:
+            if existing.id().value() == prompt.id().value():
+                new_prompts.append(prompt)
+                found = True
+            else:
+                new_prompts.append(existing)
+        if not found:
+            return Err(f'Prompt with id "{prompt.id().value()}" not found.')
+        return Ok(FavoritePrompts(tuple(new_prompts)))
+
+    def remove_prompt(
+        self, prompt_id: FavoritePromptId
+    ) -> Result["FavoritePrompts", str]:
+        new_prompts = tuple(
+            p for p in self._prompts if p.id().value() != prompt_id.value()
+        )
+        if len(new_prompts) == len(self._prompts):
+            return Err(f'Prompt with id "{prompt_id.value()}" not found.')
+        return Ok(FavoritePrompts(new_prompts))
+
+    def find_prompt(
+        self, prompt_id: FavoritePromptId
+    ) -> Result[FavoritePrompt, str]:  # pragma: no cover - simple loop
+        for prompt in self._prompts:
+            if prompt.id().value() == prompt_id.value():
+                return Ok(prompt)
+        return Err(f'Prompt with id "{prompt_id.value()}" not found.')

--- a/src/codebase_to_llm/interface/favorite_prompts.html
+++ b/src/codebase_to_llm/interface/favorite_prompts.html
@@ -16,15 +16,24 @@
         button.btn-danger { background-color: #ef4444; }
         ul { list-style: none; padding: 0; }
         li { margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center; }
-        .prompt-name { font-weight: bold; }
+        .prompt-name { font-weight: bold; cursor: pointer; color: #3b82f6; }
+        .prompt-name:hover { text-decoration: underline; }
         a { text-decoration: none; color: #3b82f6; }
     </style>
 </head>
 <body>
     <div class="container">
+        <h1>Favorite Prompts</h1>
+        <div id="message"></div>
+        
         <div class="section">
-            <h1>Favorite Prompts</h1>
-            <div id="message"></div>
+            <h2>Existing Prompts</h2>
+            <ul id="promptList"></ul>
+            <button id="createNewBtn" type="button">Create New Prompt</button>
+        </div>
+
+        <div class="section" id="promptFormSection" style="display: none;">
+            <h2 id="formTitle">Add New Prompt</h2>
             <form id="promptForm">
                 <input type="hidden" id="id" name="id">
                 <div class="form-group">
@@ -36,13 +45,9 @@
                     <textarea id="content" name="content" required></textarea>
                 </div>
                 <button id="addBtn" type="button">Add</button>
-                <button id="updateBtn" type="button">Update</button>
+                <button id="updateBtn" type="button" style="display: none;">Update</button>
+                <button id="clearBtn" type="button" style="display: none;">Clear</button>
             </form>
-        </div>
-
-        <div class="section">
-            <h2>Existing Prompts</h2>
-            <ul id="promptList"></ul>
         </div>
 
         <a href="/" id="backLink">Back to main</a>
@@ -82,6 +87,37 @@
             setTimeout(() => { el.innerHTML = ''; }, 5000);
         }
 
+        function showFormSection() {
+            document.getElementById('promptFormSection').style.display = 'block';
+        }
+
+        function hideFormSection() {
+            document.getElementById('promptFormSection').style.display = 'none';
+        }
+
+        function showAddMode() {
+            document.getElementById('addBtn').style.display = 'inline-block';
+            document.getElementById('updateBtn').style.display = 'none';
+            document.getElementById('clearBtn').style.display = 'none';
+            document.getElementById('formTitle').textContent = 'Add New Prompt';
+            showFormSection();
+        }
+
+        function showUpdateMode() {
+            document.getElementById('addBtn').style.display = 'none';
+            document.getElementById('updateBtn').style.display = 'inline-block';
+            document.getElementById('clearBtn').style.display = 'inline-block';
+            document.getElementById('formTitle').textContent = 'Update Prompt';
+            showFormSection();
+        }
+
+        function clearForm() {
+            document.getElementById('id').value = '';
+            document.getElementById('name').value = '';
+            document.getElementById('content').value = '';
+            hideFormSection();
+        }
+
         async function loadPrompts() {
             try {
                 const result = await api.getFavoritePrompts();
@@ -96,6 +132,7 @@
                         document.getElementById('id').value = p.id;
                         document.getElementById('name').value = p.name;
                         document.getElementById('content').value = p.content;
+                        showUpdateMode();
                     });
                     li.appendChild(span);
                     const delBtn = document.createElement('button');
@@ -121,7 +158,7 @@
             const content = document.getElementById('content').value;
             try {
                 await api.addFavoritePrompt(name, content);
-                document.getElementById('id').value = '';
+                clearForm();
                 showMessage('Prompt added');
                 loadPrompts();
             } catch (e) { showMessage(e.message, true); }
@@ -133,13 +170,22 @@
             const content = document.getElementById('content').value;
             try {
                 await api.updateFavoritePrompt(id, name, content);
+                clearForm();
                 showMessage('Prompt updated');
                 loadPrompts();
             } catch (e) { showMessage(e.message, true); }
+        });
+
+        document.getElementById('clearBtn').addEventListener('click', () => {
+            clearForm();
+        });
+
+        document.getElementById('createNewBtn').addEventListener('click', () => {
+            clearForm();
+            showAddMode();
         });
 
         loadPrompts();
     </script>
 </body>
 </html>
-

--- a/src/codebase_to_llm/interface/favorite_prompts.html
+++ b/src/codebase_to_llm/interface/favorite_prompts.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Favorite Prompts</title>
+    <style>
+        body { font-family: sans-serif; background-color: #f5f5f5; }
+        .container { max-width: 800px; margin: 0 auto; padding: 20px; }
+        .section { background: white; margin-bottom: 20px; padding: 25px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .form-group { margin-bottom: 15px; }
+        label { display: block; margin-bottom: 5px; }
+        input[type="text"], textarea { width: 100%; padding: 12px; border: 2px solid #ddd; border-radius: 4px; }
+        textarea { min-height: 120px; resize: vertical; }
+        button { padding: 10px 20px; border: none; border-radius: 6px; cursor: pointer; background-color: #3b82f6; color: white; }
+        button.btn-danger { background-color: #ef4444; }
+        ul { list-style: none; padding: 0; }
+        li { margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center; }
+        .prompt-name { font-weight: bold; }
+        a { text-decoration: none; color: #3b82f6; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="section">
+            <h1>Favorite Prompts</h1>
+            <div id="message"></div>
+            <form id="promptForm">
+                <input type="hidden" id="id" name="id">
+                <div class="form-group">
+                    <label for="name">Name</label>
+                    <input type="text" id="name" name="name" required>
+                </div>
+                <div class="form-group">
+                    <label for="content">Content</label>
+                    <textarea id="content" name="content" required></textarea>
+                </div>
+                <button id="addBtn" type="button">Add</button>
+                <button id="updateBtn" type="button">Update</button>
+            </form>
+        </div>
+
+        <div class="section">
+            <h2>Existing Prompts</h2>
+            <ul id="promptList"></ul>
+        </div>
+
+        <a href="/" id="backLink">Back to main</a>
+    </div>
+
+    <script>
+        class ApiClient {
+            constructor() {
+                this.baseUrl = window.location.origin;
+                this.token = localStorage.getItem('access_token');
+                if (!this.token) {
+                    window.location.href = '/';
+                }
+            }
+
+            async request(endpoint, options = {}) {
+                const url = `${this.baseUrl}${endpoint}`;
+                const headers = { 'Content-Type': 'application/json', ...options.headers };
+                if (this.token) { headers['Authorization'] = `Bearer ${this.token}`; }
+                const response = await fetch(url, { ...options, headers });
+                const data = await response.json();
+                if (!response.ok) { throw new Error(data.detail || 'Request failed'); }
+                return data;
+            }
+
+            getFavoritePrompts() { return this.request('/favorite-prompts', { method: 'GET' }); }
+            addFavoritePrompt(name, content) { return this.request('/favorite-prompts', { method: 'POST', body: JSON.stringify({ name, content }) }); }
+            updateFavoritePrompt(id, name, content) { return this.request('/favorite-prompts', { method: 'PUT', body: JSON.stringify({ id, name, content }) }); }
+            removeFavoritePrompt(id) { return this.request('/favorite-prompts', { method: 'DELETE', body: JSON.stringify({ id }) }); }
+        }
+
+        const api = new ApiClient();
+
+        function showMessage(message, isError = false) {
+            const el = document.getElementById('message');
+            el.innerHTML = `<div class="${isError ? 'error' : 'success'}">${message}</div>`;
+            setTimeout(() => { el.innerHTML = ''; }, 5000);
+        }
+
+        async function loadPrompts() {
+            try {
+                const result = await api.getFavoritePrompts();
+                const list = document.getElementById('promptList');
+                list.innerHTML = '';
+                result.prompts.forEach(p => {
+                    const li = document.createElement('li');
+                    const span = document.createElement('span');
+                    span.textContent = p.name;
+                    span.classList.add('prompt-name');
+                    span.addEventListener('click', () => {
+                        document.getElementById('id').value = p.id;
+                        document.getElementById('name').value = p.name;
+                        document.getElementById('content').value = p.content;
+                    });
+                    li.appendChild(span);
+                    const delBtn = document.createElement('button');
+                    delBtn.textContent = 'Delete';
+                    delBtn.classList.add('btn-danger');
+                    delBtn.addEventListener('click', async () => {
+                        try {
+                            await api.removeFavoritePrompt(p.id);
+                            showMessage('Prompt removed');
+                            loadPrompts();
+                        } catch (e) { showMessage(e.message, true); }
+                    });
+                    li.appendChild(delBtn);
+                    list.appendChild(li);
+                });
+            } catch (e) {
+                showMessage(e.message, true);
+            }
+        }
+
+        document.getElementById('addBtn').addEventListener('click', async () => {
+            const name = document.getElementById('name').value;
+            const content = document.getElementById('content').value;
+            try {
+                await api.addFavoritePrompt(name, content);
+                document.getElementById('id').value = '';
+                showMessage('Prompt added');
+                loadPrompts();
+            } catch (e) { showMessage(e.message, true); }
+        });
+
+        document.getElementById('updateBtn').addEventListener('click', async () => {
+            const id = document.getElementById('id').value;
+            const name = document.getElementById('name').value;
+            const content = document.getElementById('content').value;
+            try {
+                await api.updateFavoritePrompt(id, name, content);
+                showMessage('Prompt updated');
+                loadPrompts();
+            } catch (e) { showMessage(e.message, true); }
+        });
+
+        loadPrompts();
+    </script>
+</body>
+</html>
+

--- a/src/codebase_to_llm/interface/prompts_dialogs.py
+++ b/src/codebase_to_llm/interface/prompts_dialogs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List
+import uuid
 
 from PySide6.QtWidgets import (
     QDialog,
@@ -126,7 +127,8 @@ class PromptsManagerDialog(QDialog):
                     self, "Validation Error", "Prompt name cannot be empty."
                 )
                 return
-            result = FavoritePrompt.try_create(name, content)
+            new_id = str(uuid.uuid4())
+            result = FavoritePrompt.try_create(new_id, name, content)
             if result.is_err():
                 QMessageBox.warning(
                     self, "Validation Error", result.err() or "Invalid prompt."
@@ -163,7 +165,9 @@ class PromptsManagerDialog(QDialog):
                         self, "Validation Error", "Prompt name cannot be empty."
                     )
                     return
-                result = FavoritePrompt.try_create(name, content)
+                result = FavoritePrompt.try_create(
+                    favorite_prompt.id().value(), name, content
+                )
                 if result.is_err():
                     QMessageBox.warning(
                         self, "Validation Error", result.err() or "Invalid prompt."

--- a/src/codebase_to_llm/interface/web_ui.html
+++ b/src/codebase_to_llm/interface/web_ui.html
@@ -304,6 +304,7 @@
             <div class="user-info">
                 <span>Logged in as: <strong id="currentUser"></strong></span>
                 <button id="logoutBtn" class="btn-danger btn-sm" style="margin-left: 10px;">Logout</button>
+                <a href="/favorite-prompts-ui" class="btn-primary btn-sm" style="margin-left: 10px;">Favorite Prompts</a>
             </div>
 
             <!-- External Sources Section -->

--- a/src/codebase_to_llm/interface/web_ui.html
+++ b/src/codebase_to_llm/interface/web_ui.html
@@ -243,12 +243,51 @@
             display: none;
         }
 
-        .user-info {
-            text-align: right;
+        /* Navigation Bar Styling */
+        .navbar {
+            background: white;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             margin-bottom: 20px;
-            padding: 10px;
-            background: #ecf0f1;
-            border-radius: 4px;
+            border-radius: 8px;
+            padding: 0;
+        }
+
+        .navbar-content {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 15px 25px;
+        }
+
+        .navbar-brand {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .navbar-brand h2 {
+            color: #2c3e50;
+            margin: 0;
+            font-size: 1.4em;
+            font-weight: 600;
+        }
+
+        .navbar-nav {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }
+
+        .navbar-user {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            color: #555;
+            font-weight: 500;
+        }
+
+        .navbar-user strong {
+            color: #2c3e50;
         }
 
         .flex-row {
@@ -273,17 +312,65 @@
             min-width: 44px;
             padding: 12px;
         }
+
+        /* Favorite Prompts Bar Styling */
+        .favorite-prompts-bar {
+            margin: 20px 0;
+            padding: 15px;
+            background-color: #f8f9fa;
+            border-radius: 6px;
+            border: 1px solid #e9ecef;
+        }
+
+        .favorite-prompts-bar h3 {
+            margin: 0 0 10px 0;
+            font-size: 14px;
+            color: #495057;
+            font-weight: 600;
+        }
+
+        .favorite-prompts-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .favorite-prompt-item {
+            background-color: #e3f2fd;
+            color: #1565c0;
+            padding: 6px 12px;
+            border-radius: 20px;
+            font-size: 12px;
+            cursor: pointer;
+            border: 1px solid #bbdefb;
+            transition: all 0.2s ease-in-out;
+            white-space: nowrap;
+            max-width: 200px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .favorite-prompt-item:hover {
+            background-color: #bbdefb;
+            transform: translateY(-1px);
+            box-shadow: 0 2px 4px rgba(21, 101, 192, 0.2);
+        }
+
+        .favorite-prompt-item:active {
+            transform: translateY(0);
+        }
     </style>
 </head>
 <body>
     <div class="container">
-        <div class="header">
-            <h1>LLM Context Manager</h1>
-            <p>Web Interface for Context Management</p>
-        </div>
+        
 
         <!-- Login Section -->
         <div id="loginSection" class="section login-section">
+            <div class="header">
+                <h1>LLM Context Manager</h1>
+                <p>Web Interface for Context Management</p>
+            </div>
             <h2>Login</h2>
             <div id="loginMessage"></div>
             <form id="loginForm">
@@ -301,11 +388,23 @@
 
         <!-- Main Interface (hidden until logged in) -->
         <div id="mainInterface" class="hidden">
-            <div class="user-info">
-                <span>Logged in as: <strong id="currentUser"></strong></span>
-                <button id="logoutBtn" class="btn-danger btn-sm" style="margin-left: 10px;">Logout</button>
-                <a href="/favorite-prompts-ui" class="btn-primary btn-sm" style="margin-left: 10px;">Favorite Prompts</a>
-            </div>
+            <!-- Navigation Bar -->
+            <nav class="navbar">
+                <div class="navbar-content">
+                    <div class="navbar-brand">
+                        <h2>LLM Context Manager</h2>
+                    </div>
+                    <div class="navbar-nav">
+                        <a href="/favorite-prompts-ui" class="btn-primary btn-sm">Favorite Prompts</a>
+                        <div class="navbar-user">
+                            <span>Logged in as: <strong id="currentUser"></strong></span>
+                        </div>
+                        <button id="logoutBtn" class="btn-danger btn-sm">Logout</button>
+                        
+                       
+                    </div>
+                </div>
+            </nav>
 
             <!-- External Sources Section -->
             <div class="section">
@@ -336,6 +435,15 @@
                         <textarea id="promptContent" name="new_content" placeholder="Enter your prompt content here..." required></textarea>
                     </div>
                 </form>
+                
+                <!-- Favorite Prompts Bar -->
+                <div id="favoritePromptsBar" class="favorite-prompts-bar">
+                    <h3>Favorite Prompts:</h3>
+                    <div id="favoritePromptsList" class="favorite-prompts-list">
+                        <!-- Favorite prompts will be loaded here -->
+                    </div>
+                </div>
+                
                 <div id="contextMessage"></div>
                 <div style="display: flex; gap: 10px; align-items: center;">
                     <form id="contextForm" style="margin: 0;">
@@ -463,6 +571,12 @@
                     })
                 });
             }
+
+            async getFavoritePrompts() {
+                return this.request('/favorite-prompts', {
+                    method: 'GET'
+                });
+            }
         }
 
         const api = new ApiClient();
@@ -486,6 +600,44 @@
             document.getElementById('mainInterface').classList.remove('hidden');
             document.getElementById('currentUser').textContent = localStorage.getItem('username') || 'Unknown';
             loadExternalSources();
+            loadFavoritePrompts();
+        }
+
+        async function loadFavoritePrompts() {
+            try {
+                const result = await api.getFavoritePrompts();
+                const list = document.getElementById('favoritePromptsList');
+                list.innerHTML = '';
+                
+                if (result.prompts && result.prompts.length > 0) {
+                    result.prompts.forEach((prompt) => {
+                        const item = document.createElement('div');
+                        item.classList.add('favorite-prompt-item');
+                        item.textContent = prompt.name;
+                        item.title = prompt.content; // Show full content on hover
+                        
+                        item.addEventListener('click', () => {
+                            const textarea = document.getElementById('promptContent');
+                            textarea.value = prompt.content;
+                            // Trigger the auto-update
+                            textarea.dispatchEvent(new Event('input'));
+                            showMessage('promptMessage', `Loaded prompt: ${prompt.name}`);
+                        });
+                        
+                        list.appendChild(item);
+                    });
+                } else {
+                    const noPromptsMsg = document.createElement('div');
+                    noPromptsMsg.textContent = 'No favorite prompts available. Create some in the Favorite Prompts section.';
+                    noPromptsMsg.style.color = '#6c757d';
+                    noPromptsMsg.style.fontStyle = 'italic';
+                    list.appendChild(noPromptsMsg);
+                }
+            } catch (error) {
+                console.error('Failed to load favorite prompts:', error);
+                const list = document.getElementById('favoritePromptsList');
+                list.innerHTML = '<div style="color: #dc3545; font-style: italic;">Failed to load favorite prompts</div>';
+            }
         }
 
         async function loadExternalSources() {


### PR DESCRIPTION
## Summary
- allow adding, updating and removing favorite prompts
- expose favorite prompt operations through HTTP API and new web page
- add id-based retrieval for favorite prompts

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black ./`


------
https://chatgpt.com/codex/tasks/task_e_6894944961c483328b68c8724759a1d6