### PR TITLE
Add PostgreSQL repositories for user-scoped persistence

### DIFF
--- a/src/codebase_to_llm/infrastructure/sqlalchemy_api_key_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_api_key_repository.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+from typing_extensions import final
+from sqlalchemy import Column, MetaData, String, Table
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from codebase_to_llm.application.ports import ApiKeyRepositoryPort
+from codebase_to_llm.domain.api_key import ApiKeys, ApiKey, ApiKeyId
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.infrastructure.db import DatabaseSessionManager, get_engine
+
+_metadata = MetaData()
+
+_api_keys_table = Table(
+    "api_keys",
+    _metadata,
+    Column("id", String, primary_key=True),
+    Column("user_id", String, primary_key=True),
+    Column("url_provider", String, nullable=False),
+    Column("api_key_value", String, nullable=False),
+)
+
+_metadata.create_all(get_engine())
+
+
+@final
+class SqlAlchemyApiKeyRepository(ApiKeyRepositoryPort):
+    """API key repository backed by PostgreSQL."""
+
+    __slots__ = ("_user_id",)
+    _user_id: str
+
+    def __init__(self, user_id: str) -> None:
+        self._user_id = user_id
+
+    def _session(self) -> Session:
+        return DatabaseSessionManager.get_session()
+
+    def load_api_keys(self) -> Result[ApiKeys, str]:
+        session = self._session()
+        try:
+            rows = session.execute(
+                _api_keys_table.select().where(
+                    _api_keys_table.c.user_id == self._user_id
+                )
+            ).fetchall()
+            keys: list[ApiKey] = []
+            for row in rows:
+                key_result = ApiKey.try_create(
+                    row.id, row.url_provider, row.api_key_value
+                )
+                if key_result.is_err():
+                    return Err(key_result.err() or "Invalid API key data.")
+                key = key_result.ok()
+                if key is None:
+                    return Err("Invalid API key data.")
+                keys.append(key)
+            api_keys_result = ApiKeys.try_create(tuple(keys))
+            if api_keys_result.is_err():
+                return Err(api_keys_result.err() or "")
+            api_keys = api_keys_result.ok()
+            assert api_keys is not None
+            return Ok(api_keys)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def save_api_keys(self, api_keys: ApiKeys) -> Result[None, str]:
+        session = self._session()
+        try:
+            session.execute(
+                _api_keys_table.delete().where(
+                    _api_keys_table.c.user_id == self._user_id
+                )
+            )
+            for api_key in api_keys.api_keys():
+                session.execute(
+                    _api_keys_table.insert().values(
+                        id=api_key.id().value(),
+                        user_id=self._user_id,
+                        url_provider=api_key.url_provider().value(),
+                        api_key_value=api_key.api_key_value().value(),
+                    )
+                )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def find_api_key_by_id(self, api_key_id: ApiKeyId) -> Result[ApiKey, str]:
+        session = self._session()
+        try:
+            row = session.execute(
+                _api_keys_table.select().where(
+                    (_api_keys_table.c.user_id == self._user_id)
+                    & (_api_keys_table.c.id == api_key_id.value())
+                )
+            ).fetchone()
+            if row is None:
+                return Err("API key not found.")
+            key_result = ApiKey.try_create(row.id, row.url_provider, row.api_key_value)
+            if key_result.is_err():
+                return Err(key_result.err() or "Invalid API key data.")
+            key = key_result.ok()
+            if key is None:
+                return Err("Invalid API key data.")
+            return Ok(key)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_favorite_prompts_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_favorite_prompts_repository.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+from typing_extensions import final
+from sqlalchemy import Column, MetaData, String, Table
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from codebase_to_llm.application.ports import FavoritePromptsRepositoryPort
+from codebase_to_llm.domain.favorite_prompts import (
+    FavoritePrompt,
+    FavoritePrompts,
+)
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.infrastructure.db import DatabaseSessionManager, get_engine
+
+_metadata = MetaData()
+
+_favorite_prompts_table = Table(
+    "favorite_prompts",
+    _metadata,
+    Column("id", String, primary_key=True),
+    Column("user_id", String, primary_key=True),
+    Column("name", String, nullable=False),
+    Column("content", String, nullable=False),
+)
+
+_metadata.create_all(get_engine())
+
+
+@final
+class SqlAlchemyFavoritePromptsRepository(FavoritePromptsRepositoryPort):
+    """Favorite prompts repository backed by PostgreSQL."""
+
+    __slots__ = ("_user_id",)
+    _user_id: str
+
+    def __init__(self, user_id: str) -> None:
+        self._user_id = user_id
+
+    def _session(self) -> Session:
+        return DatabaseSessionManager.get_session()
+
+    def load_prompts(self) -> Result[FavoritePrompts, str]:
+        session = self._session()
+        try:
+            rows = session.execute(
+                _favorite_prompts_table.select().where(
+                    _favorite_prompts_table.c.user_id == self._user_id
+                )
+            ).fetchall()
+            prompts: list[FavoritePrompt] = []
+            for row in rows:
+                prompt_result = FavoritePrompt.try_create(row.id, row.name, row.content)
+                if prompt_result.is_err():
+                    return Err(prompt_result.err() or "Invalid prompt data.")
+                prompt = prompt_result.ok()
+                if prompt is None:
+                    return Err("Invalid prompt data.")
+                prompts.append(prompt)
+            prompts_result = FavoritePrompts.try_create(prompts)
+            if prompts_result.is_err():
+                return Err(prompts_result.err() or "")
+            prompts_value = prompts_result.ok()
+            assert prompts_value is not None
+            return Ok(prompts_value)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def save_prompts(self, prompts: FavoritePrompts) -> Result[None, str]:
+        session = self._session()
+        try:
+            session.execute(
+                _favorite_prompts_table.delete().where(
+                    _favorite_prompts_table.c.user_id == self._user_id
+                )
+            )
+            for prompt in prompts.prompts():
+                session.execute(
+                    _favorite_prompts_table.insert().values(
+                        id=prompt.id().value(),
+                        user_id=self._user_id,
+                        name=prompt.name(),
+                        content=prompt.content(),
+                    )
+                )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_recent_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_recent_repository.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+from typing_extensions import final
+from sqlalchemy import Column, Integer, MetaData, String, Table
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from codebase_to_llm.application.ports import RecentRepositoryPort
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.infrastructure.db import DatabaseSessionManager, get_engine
+
+_metadata = MetaData()
+
+_recent_repos_table = Table(
+    "recent_repos",
+    _metadata,
+    Column("user_id", String, primary_key=True),
+    Column("position", Integer, primary_key=True),
+    Column("path", String, nullable=False),
+)
+
+_metadata.create_all(get_engine())
+
+
+@final
+class SqlAlchemyRecentRepository(RecentRepositoryPort):
+    """Recent repositories backed by PostgreSQL."""
+
+    __slots__ = ("_user_id",)
+    _user_id: str
+
+    def __init__(self, user_id: str) -> None:
+        self._user_id = user_id
+
+    def _session(self) -> Session:
+        return DatabaseSessionManager.get_session()
+
+    def load_paths(self) -> Result[List[Path], str]:
+        session = self._session()
+        try:
+            rows = session.execute(
+                _recent_repos_table.select()
+                .where(_recent_repos_table.c.user_id == self._user_id)
+                .order_by(_recent_repos_table.c.position)
+            ).fetchall()
+            paths = [Path(row.path) for row in rows]
+            return Ok(paths)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def save_paths(self, paths: List[Path]) -> Result[None, str]:
+        session = self._session()
+        try:
+            session.execute(
+                _recent_repos_table.delete().where(
+                    _recent_repos_table.c.user_id == self._user_id
+                )
+            )
+            for position, path in enumerate(paths):
+                session.execute(
+                    _recent_repos_table.insert().values(
+                        user_id=self._user_id,
+                        position=position,
+                        path=str(path),
+                    )
+                )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def get_latest_repo(self) -> Result[Path, str]:
+        session = self._session()
+        try:
+            row = session.execute(
+                _recent_repos_table.select().where(
+                    (_recent_repos_table.c.user_id == self._user_id)
+                    & (_recent_repos_table.c.position == 0)
+                )
+            ).fetchone()
+            if row is None:
+                return Err("No recent repos found")
+            return Ok(Path(row.path))
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_rules_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_rules_repository.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+from typing_extensions import final
+from sqlalchemy import Boolean, Column, MetaData, String, Table
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from codebase_to_llm.application.ports import RulesRepositoryPort
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.domain.rules import Rule, Rules
+from codebase_to_llm.infrastructure.db import DatabaseSessionManager, get_engine
+
+_metadata = MetaData()
+
+_rules_table = Table(
+    "rules",
+    _metadata,
+    Column("user_id", String, primary_key=True),
+    Column("name", String, primary_key=True),
+    Column("content", String, nullable=False),
+    Column("description", String),
+    Column("enabled", Boolean, nullable=False),
+)
+
+_metadata.create_all(get_engine())
+
+
+@final
+class SqlAlchemyRulesRepository(RulesRepositoryPort):
+    """Rules repository backed by PostgreSQL."""
+
+    __slots__ = ("_user_id",)
+    _user_id: str
+
+    def __init__(self, user_id: str) -> None:
+        self._user_id = user_id
+
+    def _session(self) -> Session:
+        return DatabaseSessionManager.get_session()
+
+    def load_rules(self) -> Result[Rules, str]:
+        session = self._session()
+        try:
+            rows = session.execute(
+                _rules_table.select().where(_rules_table.c.user_id == self._user_id)
+            ).fetchall()
+            rules: list[Rule] = []
+            for row in rows:
+                rule_result = Rule.try_create(
+                    row.name, row.content, row.description, row.enabled
+                )
+                if rule_result.is_err():
+                    return Err(rule_result.err() or "Invalid rule data.")
+                rule = rule_result.ok()
+                if rule is None:
+                    return Err("Invalid rule data.")
+                rules.append(rule)
+            rules_result = Rules.try_create(rules)
+            if rules_result.is_err():
+                return Err(rules_result.err() or "")
+            rules_value = rules_result.ok()
+            assert rules_value is not None
+            return Ok(rules_value)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def save_rules(self, rules: Rules) -> Result[None, str]:
+        session = self._session()
+        try:
+            session.execute(
+                _rules_table.delete().where(_rules_table.c.user_id == self._user_id)
+            )
+            for rule in rules.rules():
+                session.execute(
+                    _rules_table.insert().values(
+                        user_id=self._user_id,
+                        name=rule.name(),
+                        content=rule.content(),
+                        description=rule.description(),
+                        enabled=rule.enabled(),
+                    )
+                )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def update_rule_enabled(self, name: str, enabled: bool) -> Result[None, str]:
+        session = self._session()
+        try:
+            result = session.execute(
+                _rules_table.update()
+                .where(
+                    (_rules_table.c.user_id == self._user_id)
+                    & (_rules_table.c.name == name)
+                )
+                .values(enabled=enabled)
+            )
+            if result.rowcount == 0:
+                session.rollback()
+                return Err("Rule not found")
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))


### PR DESCRIPTION
## Summary
- Add SqlAlchemy repositories for API keys, favorite prompts, recent repos, and rules
- Persist data per user by including `user_id` on each table

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black ./`


------
https://chatgpt.com/codex/tasks/task_e_6895a9ea2ee083329e1df1763a31cbb3