### PR TITLE
feat: add email validation via brevo smtp

### DIFF
--- a/migrations/versions/ebcef345da55_add_email_validation.py
+++ b/migrations/versions/ebcef345da55_add_email_validation.py
@@ -1,0 +1,30 @@
+"""add email and validation columns to users"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "ebcef345da55"
+down_revision = "5fc23dc1d6d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("email", sa.String(), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column(
+            "validated", sa.Boolean(), nullable=False, server_default=sa.text("0")
+        ),
+    )
+    op.add_column("users", sa.Column("validation_token", sa.String(), nullable=True))
+    op.execute("UPDATE users SET email='', validated=1, validation_token=''")
+    op.alter_column("users", "email", nullable=False)
+    op.alter_column("users", "validation_token", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("users", "validation_token")
+    op.drop_column("users", "validated")
+    op.drop_column("users", "email")

--- a/migrations/versions/ebcef345da55_add_email_validation.py
+++ b/migrations/versions/ebcef345da55_add_email_validation.py
@@ -15,11 +15,11 @@ def upgrade() -> None:
     op.add_column(
         "users",
         sa.Column(
-            "validated", sa.Boolean(), nullable=False, server_default=sa.text("0")
+            "validated", sa.Boolean(), nullable=False, server_default=sa.text("false")
         ),
     )
     op.add_column("users", sa.Column("validation_token", sa.String(), nullable=True))
-    op.execute("UPDATE users SET email='', validated=1, validation_token=''")
+    op.execute("UPDATE users SET email='', validated=true, validation_token=''")
     op.alter_column("users", "email", nullable=False)
     op.alter_column("users", "validation_token", nullable=False)
 

--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Protocol
 from codebase_to_llm.domain.api_key import ApiKeys, ApiKey, ApiKeyId
-from codebase_to_llm.domain.user import User, UserName
+from codebase_to_llm.domain.user import (
+    EmailAddress,
+    User,
+    UserName,
+    ValidationToken,
+)
 from codebase_to_llm.domain.context_buffer import (
     ContextBuffer,
     ExternalSource,
@@ -138,6 +143,20 @@ class UserRepositoryPort(Protocol):
     def add_user(self, user: User) -> Result[None, str]: ...  # pragma: no cover
 
     def find_by_name(self, name: UserName) -> Result[User, str]: ...  # pragma: no cover
+
+    def find_by_validation_token(
+        self, token: ValidationToken
+    ) -> Result[User, str]: ...  # pragma: no cover
+
+    def validate_user(self, user: User) -> Result[None, str]: ...  # pragma: no cover
+
+
+class EmailSenderPort(Protocol):
+    """Port for sending validation emails."""
+
+    def send_validation_email(
+        self, email: EmailAddress, token: ValidationToken
+    ) -> Result[None, str]: ...  # pragma: no cover
 
 
 class LLMAdapterPort(Protocol):

--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -144,6 +144,10 @@ class UserRepositoryPort(Protocol):
 
     def find_by_name(self, name: UserName) -> Result[User, str]: ...  # pragma: no cover
 
+    def find_by_email(
+        self, email: EmailAddress
+    ) -> Result[User, str]: ...  # pragma: no cover
+
     def find_by_validation_token(
         self, token: ValidationToken
     ) -> Result[User, str]: ...  # pragma: no cover

--- a/src/codebase_to_llm/application/uc_authenticate_user.py
+++ b/src/codebase_to_llm/application/uc_authenticate_user.py
@@ -4,7 +4,7 @@ from typing_extensions import final
 
 from codebase_to_llm.application.ports import UserRepositoryPort
 from codebase_to_llm.domain.result import Err, Ok, Result
-from codebase_to_llm.domain.user import User, UserName
+from codebase_to_llm.domain.user import User, UserName, EmailAddress
 
 
 @final
@@ -17,24 +17,31 @@ class AuthenticateUserUseCase:
     def __init__(self, user_repo: UserRepositoryPort) -> None:
         self._user_repo = user_repo
 
-    def execute(self, user_name: str, password: str) -> Result[User, str]:
-        name_result = UserName.try_create(user_name)
-        if name_result.is_err():
-            return Err("Invalid username.")
+    def execute(self, username_or_email: str, password: str) -> Result[User, str]:
+        # Try to find user by username first
+        name_result = UserName.try_create(username_or_email)
+        if name_result.is_ok():
+            name = name_result.ok()
+            if name is not None:
+                repo_result = self._user_repo.find_by_name(name)
+                if repo_result.is_ok():
+                    user = repo_result.ok()
+                    if user is not None and user.verify_password(password):
+                        if not user.is_validated():
+                            return Err("Account not validated.")
+                        return Ok(user)
 
-        name = name_result.ok()
-        if name is None:
-            return Err("Invalid username.")
+        # Try to find user by email if username lookup failed
+        email_result = EmailAddress.try_create(username_or_email)
+        if email_result.is_ok():
+            email = email_result.ok()
+            if email is not None:
+                repo_result = self._user_repo.find_by_email(email)
+                if repo_result.is_ok():
+                    user = repo_result.ok()
+                    if user is not None and user.verify_password(password):
+                        if not user.is_validated():
+                            return Err("Account not validated.")
+                        return Ok(user)
 
-        repo_result = self._user_repo.find_by_name(name)
-        if repo_result.is_err():
-            return Err("User not found.")
-
-        user = repo_result.ok()
-        if user is None or not user.verify_password(password):
-            return Err("Invalid credentials.")
-
-        if not user.is_validated():
-            return Err("Account not validated.")
-
-        return Ok(user)
+        return Err("Invalid credentials.")

--- a/src/codebase_to_llm/application/uc_authenticate_user.py
+++ b/src/codebase_to_llm/application/uc_authenticate_user.py
@@ -34,4 +34,7 @@ class AuthenticateUserUseCase:
         if user is None or not user.verify_password(password):
             return Err("Invalid credentials.")
 
+        if not user.is_validated():
+            return Err("Account not validated.")
+
         return Ok(user)

--- a/src/codebase_to_llm/application/uc_register_user.py
+++ b/src/codebase_to_llm/application/uc_register_user.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing_extensions import final
 from uuid import uuid4
 
-from codebase_to_llm.application.ports import UserRepositoryPort
+from codebase_to_llm.application.ports import EmailSenderPort, UserRepositoryPort
 from codebase_to_llm.domain.result import Err, Ok, Result
 from codebase_to_llm.domain.user import User
 
@@ -12,14 +12,19 @@ from codebase_to_llm.domain.user import User
 class RegisterUserUseCase:
     """Use case to register a new user."""
 
-    __slots__ = ("_user_repo",)
+    __slots__ = ("_user_repo", "_email_sender")
     _user_repo: UserRepositoryPort
+    _email_sender: EmailSenderPort
 
-    def __init__(self, user_repo: UserRepositoryPort) -> None:
+    def __init__(
+        self, user_repo: UserRepositoryPort, email_sender: EmailSenderPort
+    ) -> None:
         self._user_repo = user_repo
+        self._email_sender = email_sender
 
-    def execute(self, user_name: str, password: str) -> Result[User, str]:
-        user_result = User.try_create(str(uuid4()), user_name, password)
+    def execute(self, user_name: str, email: str, password: str) -> Result[User, str]:
+        token = str(uuid4())
+        user_result = User.try_create(str(uuid4()), user_name, email, password, token)
         if user_result.is_err():
             return Err("Invalid user.")
 
@@ -31,5 +36,11 @@ class RegisterUserUseCase:
         if save_result.is_err():
             error_msg = save_result.err()
             return Err(error_msg if error_msg is not None else "Failed to save user.")
+
+        email_result = self._email_sender.send_validation_email(
+            user.email(), user.validation_token()
+        )
+        if email_result.is_err():
+            return Err(email_result.err() or "Failed to send validation email.")
 
         return Ok(user)

--- a/src/codebase_to_llm/application/uc_validate_user.py
+++ b/src/codebase_to_llm/application/uc_validate_user.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing_extensions import final
+
+from codebase_to_llm.application.ports import UserRepositoryPort
+from codebase_to_llm.domain.result import Err, Ok, Result
+from codebase_to_llm.domain.user import User, ValidationToken
+
+
+@final
+class ValidateUserUseCase:
+    """Use case to validate a user account."""
+
+    __slots__ = ("_user_repo",)
+    _user_repo: UserRepositoryPort
+
+    def __init__(self, user_repo: UserRepositoryPort) -> None:
+        self._user_repo = user_repo
+
+    def execute(self, token_value: str) -> Result[User, str]:
+        token_result = ValidationToken.try_create(token_value)
+        if token_result.is_err():
+            return Err("Invalid token.")
+        token = token_result.ok()
+        if token is None:
+            return Err("Invalid token.")
+
+        repo_result = self._user_repo.find_by_validation_token(token)
+        if repo_result.is_err():
+            return Err("Invalid token.")
+        user = repo_result.ok()
+        if user is None:
+            return Err("Invalid token.")
+
+        updated_user = user.mark_validated()
+        save_result = self._user_repo.validate_user(updated_user)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to validate user.")
+
+        return Ok(updated_user)

--- a/src/codebase_to_llm/config.py
+++ b/src/codebase_to_llm/config.py
@@ -15,11 +15,21 @@ class AppConfig:
     """Application configuration values."""
 
     database_url: str
+    smtp_host: str
+    smtp_port: int
+    smtp_username: str
+    smtp_password: str
 
 
 def load_config() -> AppConfig:
     """Load configuration from environment variables."""
-    return AppConfig(database_url=os.getenv("DATABASE_URL", "sqlite:///./users.db"))
+    return AppConfig(
+        database_url=os.getenv("DATABASE_URL", "sqlite:///./users.db"),
+        smtp_host=os.getenv("SMTP_HOST", "smtp-relay.brevo.com"),
+        smtp_port=int(os.getenv("SMTP_PORT", "587")),
+        smtp_username=os.getenv("SMTP_USERNAME", "8d421b001@smtp-brevo.com"),
+        smtp_password=os.getenv("SMTP_PASSWORD", ""),
+    )
 
 
 CONFIG: AppConfig = load_config()

--- a/src/codebase_to_llm/config.py
+++ b/src/codebase_to_llm/config.py
@@ -19,6 +19,8 @@ class AppConfig:
     smtp_port: int
     smtp_username: str
     smtp_password: str
+    smtp_sender_name: str
+    deployment_url: str
 
 
 def load_config() -> AppConfig:
@@ -29,6 +31,8 @@ def load_config() -> AppConfig:
         smtp_port=int(os.getenv("SMTP_PORT", "587")),
         smtp_username=os.getenv("SMTP_USERNAME", "8d421b001@smtp-brevo.com"),
         smtp_password=os.getenv("SMTP_PASSWORD", ""),
+        smtp_sender_name=os.getenv("SMTP_SENDER_NAME", "CodeToMarket"),
+        deployment_url=os.getenv("DEPLOYMENT_URL", "http://localhost:8000"),
     )
 
 

--- a/src/codebase_to_llm/domain/user.py
+++ b/src/codebase_to_llm/domain/user.py
@@ -4,6 +4,7 @@ from typing_extensions import final
 from passlib.context import CryptContext
 from codebase_to_llm.domain.result import Err, Ok, Result
 from codebase_to_llm.domain.value_object import ValueObject
+from re import match
 
 # Password hashing context using bcrypt
 _pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -85,17 +86,76 @@ class PasswordHash(ValueObject):
 
 
 @final
+class EmailAddress(ValueObject):
+    """Validated email address."""
+
+    __slots__ = ("_value",)
+    _value: str
+
+    @staticmethod
+    def try_create(value: str) -> Result["EmailAddress", str]:
+        trimmed_value = value.strip()
+        if not trimmed_value:
+            return Err("Email cannot be empty.")
+        # Basic email pattern check
+        if match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", trimmed_value) is None:
+            return Err("Invalid email format.")
+        return Ok(EmailAddress(trimmed_value))
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return self._value
+
+
+@final
+class ValidationToken(ValueObject):
+    """Token used to validate a user account."""
+
+    __slots__ = ("_value",)
+    _value: str
+
+    @staticmethod
+    def try_create(value: str) -> Result["ValidationToken", str]:
+        trimmed_value = value.strip()
+        if not trimmed_value:
+            return Err("Validation token cannot be empty.")
+        return Ok(ValidationToken(trimmed_value))
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return self._value
+
+
+@final
 class User(ValueObject):
     """User entity with immutable fields."""
 
-    __slots__ = ("_id", "_name", "_password_hash")
+    __slots__ = (
+        "_id",
+        "_name",
+        "_email",
+        "_password_hash",
+        "_validated",
+        "_validation_token",
+    )
     _id: UserId
     _name: UserName
+    _email: EmailAddress
     _password_hash: PasswordHash
+    _validated: bool
+    _validation_token: ValidationToken
 
     @staticmethod
     def try_create(
-        id_value: str, name_value: str, password: str
+        id_value: str,
+        name_value: str,
+        email_value: str,
+        password: str,
+        token_value: str,
     ) -> Result["User", str]:
         id_result = UserId.try_create(id_value)
         if id_result.is_err():
@@ -105,18 +165,39 @@ class User(ValueObject):
         if name_result.is_err():
             return Err(f"Invalid username: {name_result.err()}")
 
+        email_result = EmailAddress.try_create(email_value)
+        if email_result.is_err():
+            return Err(f"Invalid email: {email_result.err()}")
+
+        token_result = ValidationToken.try_create(token_value)
+        if token_result.is_err():
+            return Err(f"Invalid token: {token_result.err()}")
+
         id_obj = id_result.ok()
         name_obj = name_result.ok()
-        if id_obj is None or name_obj is None:
+        email_obj = email_result.ok()
+        token_obj = token_result.ok()
+        if id_obj is None or name_obj is None or email_obj is None or token_obj is None:
             return Err("Unexpected error: one of the value objects is None")
 
         password_hash = PasswordHash.from_plain(password)
-        return Ok(User(id_obj, name_obj, password_hash))
+        return Ok(User(id_obj, name_obj, email_obj, password_hash, False, token_obj))
 
-    def __init__(self, id: UserId, name: UserName, password_hash: PasswordHash) -> None:
+    def __init__(
+        self,
+        id: UserId,
+        name: UserName,
+        email: EmailAddress,
+        password_hash: PasswordHash,
+        validated: bool,
+        validation_token: ValidationToken,
+    ) -> None:
         self._id = id
         self._name = name
+        self._email = email
         self._password_hash = password_hash
+        self._validated = validated
+        self._validation_token = validation_token
 
     def id(self) -> UserId:
         return self._id
@@ -124,8 +205,27 @@ class User(ValueObject):
     def name(self) -> UserName:
         return self._name
 
+    def email(self) -> EmailAddress:
+        return self._email
+
     def password_hash(self) -> PasswordHash:
         return self._password_hash
 
+    def validation_token(self) -> ValidationToken:
+        return self._validation_token
+
+    def is_validated(self) -> bool:
+        return self._validated
+
     def verify_password(self, password: str) -> bool:
         return self._password_hash.matches(password)
+
+    def mark_validated(self) -> "User":
+        return User(
+            self._id,
+            self._name,
+            self._email,
+            self._password_hash,
+            True,
+            self._validation_token,
+        )

--- a/src/codebase_to_llm/infrastructure/brevo_email_sender.py
+++ b/src/codebase_to_llm/infrastructure/brevo_email_sender.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import smtplib
+from email.message import EmailMessage
+from typing_extensions import final
+
+from codebase_to_llm.application.ports import EmailSenderPort
+from codebase_to_llm.config import CONFIG
+from codebase_to_llm.domain.result import Err, Ok, Result
+from codebase_to_llm.domain.user import EmailAddress, ValidationToken
+
+
+@final
+class BrevoEmailSender(EmailSenderPort):
+    """SMTP implementation using Brevo server."""
+
+    __slots__ = ()
+
+    def send_validation_email(
+        self, email: EmailAddress, token: ValidationToken
+    ) -> Result[None, str]:
+        message = EmailMessage()
+        message["Subject"] = "Account validation"
+        message["From"] = CONFIG.smtp_username
+        message["To"] = email.value()
+        message.set_content(f"Use this token to validate your account: {token.value()}")
+        try:
+            with smtplib.SMTP(CONFIG.smtp_host, CONFIG.smtp_port) as server:
+                server.starttls()
+                if CONFIG.smtp_username and CONFIG.smtp_password:
+                    server.login(CONFIG.smtp_username, CONFIG.smtp_password)
+                server.send_message(message)
+            return Ok(None)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))

--- a/src/codebase_to_llm/infrastructure/brevo_email_sender.py
+++ b/src/codebase_to_llm/infrastructure/brevo_email_sender.py
@@ -21,9 +21,42 @@ class BrevoEmailSender(EmailSenderPort):
     ) -> Result[None, str]:
         message = EmailMessage()
         message["Subject"] = "Account validation"
-        message["From"] = CONFIG.smtp_username
+        message["From"] = CONFIG.smtp_sender_name
         message["To"] = email.value()
-        message.set_content(f"Use this token to validate your account: {token.value()}")
+
+        validation_url = f"{CONFIG.deployment_url}/validate?token={token.value()}"
+
+        # Set plain text content
+        plain_text = f"""Please click the following link to validate your account:
+
+{validation_url}
+
+If the link doesn't work, copy and paste it into your browser.
+
+This link will expire after some time for security reasons."""
+
+        # Set HTML content
+        html_content = f"""
+        <html>
+        <body>
+            <h2>Account Validation</h2>
+            <p>Please click the button below to validate your account:</p>
+            <p>
+                <a href="{validation_url}" 
+                   style="background-color: #4CAF50; color: white; padding: 14px 20px; text-decoration: none; border-radius: 4px; display: inline-block;">
+                   Validate Account
+                </a>
+            </p>
+            <p>If the button doesn't work, copy and paste this link into your browser:</p>
+            <p><a href="{validation_url}">{validation_url}</a></p>
+            <p><small>This link will expire after some time for security reasons.</small></p>
+        </body>
+        </html>
+        """
+
+        message.set_content(plain_text)
+        message.add_alternative(html_content, subtype="html")
+
         try:
             with smtplib.SMTP(CONFIG.smtp_host, CONFIG.smtp_port) as server:
                 server.starttls()

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
@@ -81,7 +81,13 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
             email_result = EmailAddress.try_create(row.email)
             hash_result = PasswordHash.try_create(row.password_hash)
             token_result = ValidationToken.try_create(row.validation_token)
-            if id_result.is_err() or name_result.is_err() or hash_result.is_err():
+            if (
+                id_result.is_err()
+                or name_result.is_err()
+                or email_result.is_err()
+                or hash_result.is_err()
+                or token_result.is_err()
+            ):
                 return Err("Invalid user data.")
 
             id_obj = id_result.ok()
@@ -89,7 +95,13 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
             email_obj = email_result.ok()
             hash_obj = hash_result.ok()
             token_obj = token_result.ok()
-            if id_obj is None or name_obj is None or hash_obj is None:
+            if (
+                id_obj is None
+                or name_obj is None
+                or email_obj is None
+                or hash_obj is None
+                or token_obj is None
+            ):
                 return Err("Invalid user data.")
 
             return Ok(

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 import logging
 
 from typing_extensions import final
-from sqlalchemy import Column, String, Table
+from sqlalchemy import Boolean, Column, String, Table
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from codebase_to_llm.application.ports import UserRepositoryPort
 from codebase_to_llm.domain.result import Err, Ok, Result
-from codebase_to_llm.domain.user import PasswordHash, User, UserId, UserName
+from codebase_to_llm.domain.user import (
+    EmailAddress,
+    PasswordHash,
+    User,
+    UserId,
+    UserName,
+    ValidationToken,
+)
 from codebase_to_llm.infrastructure.db import DatabaseSessionManager, get_metadata
 
 _users_table = Table(
@@ -16,7 +23,10 @@ _users_table = Table(
     get_metadata(),
     Column("id", String, primary_key=True),
     Column("name", String, unique=True, nullable=False),
+    Column("email", String, nullable=False),
     Column("password_hash", String, nullable=False),
+    Column("validated", Boolean, nullable=False),
+    Column("validation_token", String, nullable=False),
 )
 
 
@@ -36,7 +46,10 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
                 _users_table.insert().values(
                     id=user.id().value(),
                     name=user.name().value(),
+                    email=user.email().value(),
                     password_hash=user.password_hash().value(),
+                    validated=user.is_validated(),
+                    validation_token=user.validation_token().value(),
                 )
             )
             session.commit()
@@ -63,21 +76,117 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
             ).fetchone()
             if row is None:
                 return Err("User not found.")
-
             id_result = UserId.try_create(row.id)
             name_result = UserName.try_create(row.name)
+            email_result = EmailAddress.try_create(row.email)
             hash_result = PasswordHash.try_create(row.password_hash)
-            if id_result.is_err() or name_result.is_err() or hash_result.is_err():
+            token_result = ValidationToken.try_create(row.validation_token)
+            if (
+                id_result.is_err()
+                or name_result.is_err()
+                or email_result.is_err()
+                or hash_result.is_err()
+                or token_result.is_err()
+            ):
                 return Err("Invalid user data.")
 
             id_obj = id_result.ok()
             name_obj = name_result.ok()
+            email_obj = email_result.ok()
             hash_obj = hash_result.ok()
-            if id_obj is None or name_obj is None or hash_obj is None:
+            token_obj = token_result.ok()
+            if (
+                id_obj is None
+                or name_obj is None
+                or email_obj is None
+                or hash_obj is None
+                or token_obj is None
+            ):
                 return Err("Invalid user data.")
 
-            return Ok(User(id_obj, name_obj, hash_obj))
+            return Ok(
+                User(
+                    id_obj,
+                    name_obj,
+                    email_obj,
+                    hash_obj,
+                    bool(row.validated),
+                    token_obj,
+                )
+            )
         except Exception as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+        finally:
+            session.close()
+
+    def find_by_validation_token(self, token: ValidationToken) -> Result[User, str]:
+        session = self._session()
+        try:
+            row = session.execute(
+                _users_table.select().where(
+                    _users_table.c.validation_token == token.value()
+                )
+            ).fetchone()
+            if row is None:
+                return Err("User not found.")
+
+            id_result = UserId.try_create(row.id)
+            name_result = UserName.try_create(row.name)
+            email_result = EmailAddress.try_create(row.email)
+            hash_result = PasswordHash.try_create(row.password_hash)
+            token_result = ValidationToken.try_create(row.validation_token)
+            if (
+                id_result.is_err()
+                or name_result.is_err()
+                or email_result.is_err()
+                or hash_result.is_err()
+                or token_result.is_err()
+            ):
+                return Err("Invalid user data.")
+
+            id_obj = id_result.ok()
+            name_obj = name_result.ok()
+            email_obj = email_result.ok()
+            hash_obj = hash_result.ok()
+            token_obj = token_result.ok()
+            if (
+                id_obj is None
+                or name_obj is None
+                or email_obj is None
+                or hash_obj is None
+                or token_obj is None
+            ):
+                return Err("Invalid user data.")
+
+            return Ok(
+                User(
+                    id_obj,
+                    name_obj,
+                    email_obj,
+                    hash_obj,
+                    bool(row.validated),
+                    token_obj,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+        finally:
+            session.close()
+
+    def validate_user(self, user: User) -> Result[None, str]:
+        session = self._session()
+        try:
+            session.execute(
+                _users_table.update()
+                .where(_users_table.c.id == user.id().value())
+                .values(validated=True)
+            )
+            session.commit()
+            return Ok(None)
+        except Exception as exc:  # noqa: BLE001
+            session.rollback()
             logging.warning(str(exc))
             return Err(str(exc))
         finally:

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
@@ -81,11 +81,7 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
             email_result = EmailAddress.try_create(row.email)
             hash_result = PasswordHash.try_create(row.password_hash)
             token_result = ValidationToken.try_create(row.validation_token)
-            if (
-                id_result.is_err()
-                or name_result.is_err()
-                or hash_result.is_err()
-            ):
+            if id_result.is_err() or name_result.is_err() or hash_result.is_err():
                 return Err("Invalid user data.")
 
             id_obj = id_result.ok()
@@ -93,11 +89,7 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
             email_obj = email_result.ok()
             hash_obj = hash_result.ok()
             token_obj = token_result.ok()
-            if (
-                id_obj is None
-                or name_obj is None
-                or hash_obj is None
-            ):
+            if id_obj is None or name_obj is None or hash_obj is None:
                 return Err("Invalid user data.")
 
             return Ok(

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_user_repository.py
@@ -84,9 +84,7 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
             if (
                 id_result.is_err()
                 or name_result.is_err()
-                or email_result.is_err()
                 or hash_result.is_err()
-                or token_result.is_err()
             ):
                 return Err("Invalid user data.")
 
@@ -98,9 +96,7 @@ class SqlAlchemyUserRepository(UserRepositoryPort):
             if (
                 id_obj is None
                 or name_obj is None
-                or email_obj is None
                 or hash_obj is None
-                or token_obj is None
             ):
                 return Err("Invalid user data.")
 

--- a/src/codebase_to_llm/interface/http_api.py
+++ b/src/codebase_to_llm/interface/http_api.py
@@ -229,12 +229,16 @@ def register_user(request: RegisterRequest) -> dict[str, str]:
 
 
 @app.get("/validate")
-def validate_user(token: str) -> dict[str, str]:
+def validate_user(token: str) -> FileResponse:
+    """Validate user account using the token from email."""
     use_case = ValidateUserUseCase(_user_repo)
     result = use_case.execute(token)
     if result.is_err():
         raise HTTPException(status_code=400, detail=result.err())
-    return {"status": "validated"}
+
+    # Redirect to login page after successful validation
+    html_file_path = Path(__file__).parent / "validation_success.html"
+    return FileResponse(html_file_path, media_type="text/html")
 
 
 class Token(BaseModel):

--- a/src/codebase_to_llm/interface/http_api.py
+++ b/src/codebase_to_llm/interface/http_api.py
@@ -77,6 +77,7 @@ from codebase_to_llm.application.uc_get_favorite_prompt import (
 from codebase_to_llm.domain.api_key import ApiKeyId
 from codebase_to_llm.application.uc_register_user import RegisterUserUseCase
 from codebase_to_llm.application.uc_authenticate_user import AuthenticateUserUseCase
+from codebase_to_llm.application.uc_validate_user import ValidateUserUseCase
 from codebase_to_llm.domain.user import User, UserName
 
 from codebase_to_llm.infrastructure.sqlalchemy_api_key_repository import (
@@ -107,6 +108,7 @@ from codebase_to_llm.infrastructure.url_external_source_repository import (
 from codebase_to_llm.infrastructure.sqlalchemy_user_repository import (
     SqlAlchemyUserRepository,
 )
+from codebase_to_llm.infrastructure.brevo_email_sender import BrevoEmailSender
 
 # Load environment variables from .env-development file
 load_dotenv(".env-development")
@@ -190,6 +192,7 @@ _clipboard = InMemoryClipboardService()
 _directory_repo = FileSystemDirectoryRepository(Path.cwd())
 _llm_adapter = OpenAILLMAdapter()
 _user_repo = SqlAlchemyUserRepository()
+_email_sender = BrevoEmailSender()
 
 
 def get_user_repositories(user: User) -> tuple[
@@ -210,18 +213,28 @@ def get_user_repositories(user: User) -> tuple[
 
 class RegisterRequest(BaseModel):
     user_name: str
+    email: str
     password: str
 
 
 @app.post("/register")
 def register_user(request: RegisterRequest) -> dict[str, str]:
-    use_case = RegisterUserUseCase(_user_repo)
-    result = use_case.execute(request.user_name, request.password)
+    use_case = RegisterUserUseCase(_user_repo, _email_sender)
+    result = use_case.execute(request.user_name, request.email, request.password)
     if result.is_err():
         raise HTTPException(status_code=400, detail=result.err())
     user = result.ok()
     assert user is not None
     return {"id": user.id().value(), "user_name": user.name().value()}
+
+
+@app.get("/validate")
+def validate_user(token: str) -> dict[str, str]:
+    use_case = ValidateUserUseCase(_user_repo)
+    result = use_case.execute(token)
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    return {"status": "validated"}
 
 
 class Token(BaseModel):

--- a/src/codebase_to_llm/interface/register.html
+++ b/src/codebase_to_llm/interface/register.html
@@ -22,6 +22,10 @@
                     <input type="text" id="username" name="username" required>
                 </div>
                 <div class="form-group">
+                    <label for="email">Email:</label>
+                    <input type="email" id="email" name="email" required>
+                </div>
+                <div class="form-group">
                     <label for="password">Password:</label>
                     <input type="password" id="password" name="password" required>
                 </div>
@@ -45,7 +49,7 @@
                 this.token = localStorage.getItem('access_token');
             }
 
-            async register(username, password) {
+            async register(username, email, password) {
                 const response = await fetch(`${this.baseUrl}/register`, {
                     method: 'POST',
                     headers: {
@@ -53,6 +57,7 @@
                     },
                     body: JSON.stringify({
                         user_name: username,
+                        email: email,
                         password: password
                     })
                 });
@@ -83,6 +88,7 @@
             e.preventDefault();
             const formData = new FormData(e.target);
             const username = formData.get('username');
+            const email = formData.get('email');
             const password = formData.get('password');
             const confirmPassword = formData.get('confirmPassword');
 
@@ -99,8 +105,8 @@
             }
 
             try {
-                await api.register(username, password);
-                showMessage('registerMessage', 'Account created successfully! Redirecting to login...');
+                await api.register(username, email, password);
+                showMessage('registerMessage', 'Account created. Check your email to validate before logging in.');
                 setTimeout(() => {
                     window.location.href = '/login';
                 }, 2000);

--- a/src/codebase_to_llm/interface/validation_success.html
+++ b/src/codebase_to_llm/interface/validation_success.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Account Validated - CodeToMarket</title>
+    <link rel="stylesheet" href="/web_ui.css">
+    <style>
+        .success-container {
+            max-width: 500px;
+            margin: 100px auto;
+            padding: 40px;
+            background: white;
+            border-radius: 10px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            text-align: center;
+        }
+        
+        .success-icon {
+            font-size: 64px;
+            color: #4CAF50;
+            margin-bottom: 20px;
+        }
+        
+        .success-title {
+            color: #333;
+            font-size: 28px;
+            margin-bottom: 15px;
+            font-weight: 600;
+        }
+        
+        .success-message {
+            color: #666;
+            font-size: 16px;
+            line-height: 1.5;
+            margin-bottom: 30px;
+        }
+        
+        .login-button {
+            background-color: #4CAF50;
+            color: white;
+            padding: 12px 30px;
+            border: none;
+            border-radius: 5px;
+            font-size: 16px;
+            cursor: pointer;
+            text-decoration: none;
+            display: inline-block;
+            transition: background-color 0.3s;
+        }
+        
+        .login-button:hover {
+            background-color: #45a049;
+        }
+        
+        body {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            padding: 0;
+            min-height: 100vh;
+        }
+    </style>
+</head>
+<body>
+    <div class="success-container">
+        <div class="success-icon">✓</div>
+        <h1 class="success-title">Account Validated!</h1>
+        <p class="success-message">
+            Your account has been successfully validated. You can now log in to access all features of CodeToMarket.
+        </p>
+        <a href="/login" class="login-button">Go to Login</a>
+    </div>
+    
+    <script>
+        // Auto-redirect to login page after 5 seconds
+        setTimeout(function() {
+            window.location.href = '/login';
+        }, 5000);
+    </script>
+</body>
+</html>

--- a/tests/test_user_registration_validation.py
+++ b/tests/test_user_registration_validation.py
@@ -25,6 +25,12 @@ class InMemoryUserRepository(UserRepositoryPort):
             return Err("User not found.")
         return Ok(user)
 
+    def find_by_email(self, email: EmailAddress) -> Result[User, str]:
+        for user in self._users.values():
+            if user.email().value() == email.value():
+                return Ok(user)
+        return Err("User not found.")
+
     def find_by_validation_token(self, token: ValidationToken) -> Result[User, str]:
         for user in self._users.values():
             if user.validation_token().value() == token.value():

--- a/tests/test_user_registration_validation.py
+++ b/tests/test_user_registration_validation.py
@@ -1,0 +1,66 @@
+from codebase_to_llm.application.uc_register_user import RegisterUserUseCase
+from codebase_to_llm.application.uc_authenticate_user import AuthenticateUserUseCase
+from codebase_to_llm.application.uc_validate_user import ValidateUserUseCase
+from codebase_to_llm.application.ports import UserRepositoryPort, EmailSenderPort
+from codebase_to_llm.domain.result import Err, Ok, Result
+from codebase_to_llm.domain.user import (
+    EmailAddress,
+    User,
+    UserName,
+    ValidationToken,
+)
+
+
+class InMemoryUserRepository(UserRepositoryPort):
+    def __init__(self) -> None:
+        self._users: dict[str, User] = {}
+
+    def add_user(self, user: User) -> Result[None, str]:
+        self._users[user.name().value()] = user
+        return Ok(None)
+
+    def find_by_name(self, name: UserName) -> Result[User, str]:
+        user = self._users.get(name.value())
+        if user is None:
+            return Err("User not found.")
+        return Ok(user)
+
+    def find_by_validation_token(self, token: ValidationToken) -> Result[User, str]:
+        for user in self._users.values():
+            if user.validation_token().value() == token.value():
+                return Ok(user)
+        return Err("User not found.")
+
+    def validate_user(self, user: User) -> Result[None, str]:
+        self._users[user.name().value()] = user
+        return Ok(None)
+
+
+class FakeEmailSender(EmailSenderPort):
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+
+    def send_validation_email(
+        self, email: EmailAddress, token: ValidationToken
+    ) -> Result[None, str]:
+        self.sent.append((email.value(), token.value()))
+        return Ok(None)
+
+
+def test_user_must_validate_before_login() -> None:
+    repo = InMemoryUserRepository()
+    email_sender = FakeEmailSender()
+    register = RegisterUserUseCase(repo, email_sender)
+    result = register.execute("alice", "alice@example.com", "secret")
+    assert result.is_ok()
+    user = result.ok()
+    assert user is not None
+
+    auth = AuthenticateUserUseCase(repo)
+    assert auth.execute("alice", "secret").is_err()
+
+    token = user.validation_token().value()
+    validate = ValidateUserUseCase(repo)
+    assert validate.execute(token).is_ok()
+
+    assert auth.execute("alice", "secret").is_ok()


### PR DESCRIPTION
## Summary
- require email when registering a user and generate validation token
- send validation email through Brevo SMTP and block login until validated
- add migration for email and validation columns; update UI and tests

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black ./`


------
https://chatgpt.com/codex/tasks/task_e_68983d4608e48332b609f79deb380038