### PR TITLE
feat: manage rules via http api

### DIFF
--- a/src/codebase_to_llm/application/uc_add_rule.py
+++ b/src/codebase_to_llm/application/uc_add_rule.py
@@ -1,0 +1,57 @@
+"""Use case for adding a rule."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import RulesRepositoryPort
+from codebase_to_llm.domain.rules import Rule, Rules
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class AddRuleUseCase:
+    """Adds a new rule and persists it."""
+
+    def __init__(self, repo: RulesRepositoryPort):
+        self._repo = repo
+
+    def execute(
+        self,
+        name: str,
+        content: str,
+        description: str | None = None,
+        enabled: bool = True,
+    ) -> Result[Rule, str]:
+        rule_result = Rule.try_create(name, content, description, enabled)
+        if rule_result.is_err():
+            return Err(rule_result.err() or "Failed to create rule.")
+        rule = rule_result.ok()
+        if rule is None:
+            return Err("Failed to create rule.")
+
+        load_result = self._repo.load_rules()
+        if load_result.is_err():
+            empty_result = Rules.try_create([])
+            if empty_result.is_err():
+                return Err(empty_result.err() or "Unknown error creating collection.")
+            rules = empty_result.ok()
+        else:
+            rules = load_result.ok()
+            if rules is None:
+                empty_result = Rules.try_create([])
+                if empty_result.is_err():
+                    return Err(
+                        empty_result.err() or "Unknown error creating collection."
+                    )
+                rules = empty_result.ok()
+
+        assert rules is not None
+        add_result = rules.add_rule(rule)
+        if add_result.is_err():
+            return Err(add_result.err() or "Failed to add rule.")
+        updated_rules = add_result.ok()
+        assert updated_rules is not None
+
+        save_result = self._repo.save_rules(updated_rules)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to save rules.")
+
+        return Ok(rule)

--- a/src/codebase_to_llm/application/uc_get_rules.py
+++ b/src/codebase_to_llm/application/uc_get_rules.py
@@ -1,0 +1,17 @@
+"""Use case for retrieving rules."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import RulesRepositoryPort
+from codebase_to_llm.domain.rules import Rules
+from codebase_to_llm.domain.result import Result
+
+
+class GetRulesUseCase:
+    """Loads the current rules from the repository."""
+
+    def __init__(self, repo: RulesRepositoryPort):
+        self._repo = repo
+
+    def execute(self) -> Result[Rules, str]:
+        return self._repo.load_rules()

--- a/src/codebase_to_llm/application/uc_remove_rule.py
+++ b/src/codebase_to_llm/application/uc_remove_rule.py
@@ -1,0 +1,33 @@
+"""Use case for removing a rule."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import RulesRepositoryPort
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class RemoveRuleUseCase:
+    """Removes a rule identified by its name."""
+
+    def __init__(self, repo: RulesRepositoryPort):
+        self._repo = repo
+
+    def execute(self, name: str) -> Result[None, str]:
+        load_result = self._repo.load_rules()
+        if load_result.is_err():
+            return Err(load_result.err() or "Failed to load rules.")
+        rules = load_result.ok()
+        if rules is None:
+            return Err("Failed to load rules.")
+
+        before = len(rules.rules())
+        new_rules = rules.remove_rule(name)
+        after = len(new_rules.rules())
+        if before == after:
+            return Err(f'Rule with name "{name}" not found.')
+
+        save_result = self._repo.save_rules(new_rules)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to save rules.")
+
+        return Ok(None)

--- a/src/codebase_to_llm/application/uc_update_rule.py
+++ b/src/codebase_to_llm/application/uc_update_rule.py
@@ -1,0 +1,47 @@
+"""Use case for updating an existing rule."""
+
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import RulesRepositoryPort
+from codebase_to_llm.domain.rules import Rule
+from codebase_to_llm.domain.result import Err, Ok, Result
+
+
+class UpdateRuleUseCase:
+    """Updates a rule identified by its name."""
+
+    def __init__(self, repo: RulesRepositoryPort):
+        self._repo = repo
+
+    def execute(
+        self,
+        name: str,
+        content: str,
+        description: str | None = None,
+        enabled: bool = True,
+    ) -> Result[Rule, str]:
+        rule_result = Rule.try_create(name, content, description, enabled)
+        if rule_result.is_err():
+            return Err(rule_result.err() or "Failed to create rule.")
+        rule = rule_result.ok()
+        if rule is None:
+            return Err("Failed to create rule.")
+
+        load_result = self._repo.load_rules()
+        if load_result.is_err():
+            return Err(load_result.err() or "Failed to load rules.")
+        rules = load_result.ok()
+        if rules is None:
+            return Err("Failed to load rules.")
+
+        update_result = rules.update_rule(rule)
+        if update_result.is_err():
+            return Err(update_result.err() or "Failed to update rule.")
+        updated_rules = update_result.ok()
+        assert updated_rules is not None
+
+        save_result = self._repo.save_rules(updated_rules)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to save rules.")
+
+        return Ok(rule)

--- a/src/codebase_to_llm/domain/rules.py
+++ b/src/codebase_to_llm/domain/rules.py
@@ -82,6 +82,25 @@ class Rules(ValueObject):
                 parts.append(r.name())
         return "\n".join(parts)
 
+    def add_rule(self, rule: Rule) -> Result["Rules", str]:
+        for existing in self._rules:
+            if existing.name() == rule.name():
+                return Err(f'Rule with name "{rule.name()}" already exists.')
+        return Ok(Rules(self._rules + (rule,)))
+
+    def update_rule(self, rule: Rule) -> Result["Rules", str]:
+        new_rules = []
+        found = False
+        for existing in self._rules:
+            if existing.name() == rule.name():
+                new_rules.append(rule)
+                found = True
+            else:
+                new_rules.append(existing)
+        if not found:
+            return Err(f'Rule with name "{rule.name()}" not found.')
+        return Ok(Rules(tuple(new_rules)))
+
     def update_rule_enabled(self, name: str, enabled: bool) -> "Rules":
         new_rules: tuple[Rule, ...] = tuple()
         for rule in self._rules:

--- a/src/codebase_to_llm/interface/http_api.py
+++ b/src/codebase_to_llm/interface/http_api.py
@@ -74,6 +74,10 @@ from codebase_to_llm.application.uc_get_favorite_prompts import (
 from codebase_to_llm.application.uc_get_favorite_prompt import (
     GetFavoritePromptUseCase,
 )
+from codebase_to_llm.application.uc_add_rule import AddRuleUseCase
+from codebase_to_llm.application.uc_get_rules import GetRulesUseCase
+from codebase_to_llm.application.uc_update_rule import UpdateRuleUseCase
+from codebase_to_llm.application.uc_remove_rule import RemoveRuleUseCase
 from codebase_to_llm.domain.api_key import ApiKeyId
 from codebase_to_llm.application.uc_register_user import RegisterUserUseCase
 from codebase_to_llm.application.uc_authenticate_user import AuthenticateUserUseCase
@@ -667,6 +671,103 @@ def remove_favorite_prompt(
     if result.is_err():
         raise HTTPException(status_code=400, detail=result.err())
     return {"id": request.id}
+
+
+class RuleCreateRequest(BaseModel):
+    name: str
+    content: str
+    description: str | None = None
+    enabled: bool = True
+
+
+class RuleUpdateRequest(BaseModel):
+    name: str
+    content: str
+    description: str | None = None
+    enabled: bool = True
+
+
+class RuleNameRequest(BaseModel):
+    name: str
+
+
+@app.get("/rules")
+def get_rules(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> list[dict[str, Any]]:
+    _, rules_repo, _, _ = get_user_repositories(current_user)
+    use_case = GetRulesUseCase(rules_repo)
+    result = use_case.execute()
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    rules = result.ok()
+    assert rules is not None
+    return [
+        {
+            "name": r.name(),
+            "content": r.content(),
+            "description": r.description(),
+            "enabled": r.enabled(),
+        }
+        for r in rules.rules()
+    ]
+
+
+@app.post("/rules")
+def add_rule(
+    request: RuleCreateRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, Any]:
+    _, rules_repo, _, _ = get_user_repositories(current_user)
+    use_case = AddRuleUseCase(rules_repo)
+    result = use_case.execute(
+        request.name, request.content, request.description, request.enabled
+    )
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    rule = result.ok()
+    assert rule is not None
+    return {
+        "name": rule.name(),
+        "content": rule.content(),
+        "description": rule.description(),
+        "enabled": rule.enabled(),
+    }
+
+
+@app.put("/rules")
+def update_rule(
+    request: RuleUpdateRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, Any]:
+    _, rules_repo, _, _ = get_user_repositories(current_user)
+    use_case = UpdateRuleUseCase(rules_repo)
+    result = use_case.execute(
+        request.name, request.content, request.description, request.enabled
+    )
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    rule = result.ok()
+    assert rule is not None
+    return {
+        "name": rule.name(),
+        "content": rule.content(),
+        "description": rule.description(),
+        "enabled": rule.enabled(),
+    }
+
+
+@app.delete("/rules")
+def remove_rule(
+    request: RuleNameRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, str]:
+    _, rules_repo, _, _ = get_user_repositories(current_user)
+    use_case = RemoveRuleUseCase(rules_repo)
+    result = use_case.execute(request.name)
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    return {"name": request.name}
 
 
 class AddFileAsPromptVariableRequest(BaseModel):

--- a/tests/test_rules_use_cases.py
+++ b/tests/test_rules_use_cases.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_to_llm.application.uc_add_rule import AddRuleUseCase
+from codebase_to_llm.application.uc_get_rules import GetRulesUseCase
+from codebase_to_llm.application.uc_update_rule import UpdateRuleUseCase
+from codebase_to_llm.application.uc_remove_rule import RemoveRuleUseCase
+from codebase_to_llm.infrastructure.filesystem_rules_repository import (
+    RulesRepository,
+)
+
+
+def _repo(tmp_path: Path) -> RulesRepository:
+    return RulesRepository(tmp_path / "rules.json")
+
+
+def test_add_and_get_rules(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    add_uc = AddRuleUseCase(repo)
+    result = add_uc.execute("rule1", "content1", "desc1", True)
+    assert result.is_ok()
+
+    get_uc = GetRulesUseCase(repo)
+    rules_result = get_uc.execute()
+    assert rules_result.is_ok()
+    rules = rules_result.ok()
+    assert rules is not None
+    assert len(rules.rules()) == 1
+    rule = rules.rules()[0]
+    assert rule.name() == "rule1"
+    assert rule.content() == "content1"
+    assert rule.description() == "desc1"
+    assert rule.enabled()
+
+
+def test_update_and_remove_rule(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    add_uc = AddRuleUseCase(repo)
+    add_result = add_uc.execute("rule1", "content1", None, True)
+    assert add_result.is_ok()
+
+    update_uc = UpdateRuleUseCase(repo)
+    update_result = update_uc.execute("rule1", "new", "d", False)
+    assert update_result.is_ok()
+
+    get_uc = GetRulesUseCase(repo)
+    rules_result = get_uc.execute()
+    assert rules_result.is_ok()
+    rules = rules_result.ok()
+    assert rules is not None
+    rule = rules.rules()[0]
+    assert rule.content() == "new"
+    assert rule.description() == "d"
+    assert not rule.enabled()
+
+    remove_uc = RemoveRuleUseCase(repo)
+    remove_result = remove_uc.execute("rule1")
+    assert remove_result.is_ok()
+
+    rules_after = get_uc.execute().ok()
+    assert rules_after is not None
+    assert len(rules_after.rules()) == 0


### PR DESCRIPTION
## Summary
- add rule management use cases
- expose CRUD rules endpoints in http api
- support rule updates within domain

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`


------
https://chatgpt.com/codex/tasks/task_e_68986fa266c883328aebd7d88e6737d3