### PR TITLE
Add file & directory entities with CRUD routes

### DIFF
--- a/migrations/versions/0c4e1b38f3f4_add_files_and_directories.py
+++ b/migrations/versions/0c4e1b38f3f4_add_files_and_directories.py
@@ -1,0 +1,34 @@
+"""add files and directories tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0c4e1b38f3f4"
+down_revision = "ebcef345da55"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "directories",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("parent_id", sa.String(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "files",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("directory_id", sa.String(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("files")
+    op.drop_table("directories")

--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -12,7 +12,7 @@ from codebase_to_llm.domain.user import (
 from codebase_to_llm.domain.context_buffer import (
     ContextBuffer,
     ExternalSource,
-    File,
+    File as BufferFile,
     Snippet,
 )
 from codebase_to_llm.domain.prompt import Prompt, PromptVariable
@@ -20,6 +20,8 @@ from codebase_to_llm.domain.prompt import Prompt, PromptVariable
 from codebase_to_llm.domain.result import Result
 from codebase_to_llm.domain.rules import Rules
 from codebase_to_llm.domain.favorite_prompts import FavoritePrompts
+from codebase_to_llm.domain.stored_file import StoredFile, StoredFileId
+from codebase_to_llm.domain.directory import Directory, DirectoryId
 
 
 class ClipboardPort(Protocol):
@@ -80,7 +82,7 @@ class ContextBufferPort(Protocol):
         self, url: str
     ) -> Result[None, str]: ...  # pragma: no cover
 
-    def add_file(self, file: File) -> Result[None, str]: ...  # pragma: no cover
+    def add_file(self, file: BufferFile) -> Result[None, str]: ...  # pragma: no cover
     def remove_file(self, path: Path) -> Result[None, str]: ...  # pragma: no cover
 
     def add_snippet(
@@ -93,7 +95,7 @@ class ContextBufferPort(Protocol):
     def get_external_sources(
         self,
     ) -> list[ExternalSource]: ...  # pragma: no cover
-    def get_files(self) -> list[File]: ...  # pragma: no cover
+    def get_files(self) -> list[BufferFile]: ...  # pragma: no cover
     def get_snippets(self) -> list[Snippet]: ...  # pragma: no cover
     def get_context_buffer(self) -> ContextBuffer: ...  # pragma: no cover
 
@@ -169,3 +171,47 @@ class LLMAdapterPort(Protocol):
     def generate_response(
         self, prompt: str, model: str, api_key: ApiKey
     ) -> Result[str, str]: ...  # pragma: no cover
+
+
+class FileStoragePort(Protocol):
+    """Port for persisting file contents."""
+
+    def save(
+        self, file: StoredFile, content: bytes
+    ) -> Result[None, str]: ...  # pragma: no cover
+
+    def load(self, file: StoredFile) -> Result[bytes, str]: ...  # pragma: no cover
+
+    def delete(self, file: StoredFile) -> Result[None, str]: ...  # pragma: no cover
+
+
+class FileRepositoryPort(Protocol):
+    """Port for CRUD operations on file metadata and access rights."""
+
+    def add(self, file: StoredFile) -> Result[None, str]: ...  # pragma: no cover
+
+    def get(
+        self, file_id: StoredFileId
+    ) -> Result[StoredFile, str]: ...  # pragma: no cover
+
+    def update(self, file: StoredFile) -> Result[None, str]: ...  # pragma: no cover
+
+    def remove(
+        self, file_id: StoredFileId
+    ) -> Result[None, str]: ...  # pragma: no cover
+
+
+class DirectoryStructureRepositoryPort(Protocol):
+    """Port for CRUD operations on user directories."""
+
+    def add(self, directory: Directory) -> Result[None, str]: ...  # pragma: no cover
+
+    def get(
+        self, directory_id: DirectoryId
+    ) -> Result[Directory, str]: ...  # pragma: no cover
+
+    def update(self, directory: Directory) -> Result[None, str]: ...  # pragma: no cover
+
+    def remove(
+        self, directory_id: DirectoryId
+    ) -> Result[None, str]: ...  # pragma: no cover

--- a/src/codebase_to_llm/application/uc_add_directory.py
+++ b/src/codebase_to_llm/application/uc_add_directory.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import DirectoryStructureRepositoryPort
+from codebase_to_llm.domain.directory import Directory, DirectoryId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class AddDirectoryUseCase:
+    """Use case for creating a directory."""
+
+    def __init__(self, repo: DirectoryStructureRepositoryPort) -> None:
+        self._repo = repo
+
+    def execute(
+        self,
+        id_value: str,
+        owner_id_value: str,
+        name: str,
+        parent_id_value: str | None = None,
+    ) -> Result[Directory, str]:
+        owner_result = UserId.try_create(owner_id_value)
+        if owner_result.is_err():
+            return Err(owner_result.err() or "Invalid owner id")
+        owner_id = owner_result.ok()
+        assert owner_id is not None
+
+        parent_id = None
+        if parent_id_value is not None:
+            parent_result = DirectoryId.try_create(parent_id_value)
+            if parent_result.is_err():
+                return Err(parent_result.err() or "Invalid parent id")
+            parent_id = parent_result.ok()
+            assert parent_id is not None
+
+        dir_result = Directory.try_create(id_value, owner_id, name, parent_id)
+        if dir_result.is_err():
+            return Err(dir_result.err() or "Invalid directory data")
+        directory = dir_result.ok()
+        assert directory is not None
+
+        save_result = self._repo.add(directory)
+        if save_result.is_err():
+            return Err(save_result.err() or "Failed to save directory")
+
+        return Ok(directory)

--- a/src/codebase_to_llm/application/uc_add_file.py
+++ b/src/codebase_to_llm/application/uc_add_file.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FileRepositoryPort, FileStoragePort
+from codebase_to_llm.domain.stored_file import StoredFile
+from codebase_to_llm.domain.directory import DirectoryId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class AddFileUseCase:
+    """Use case for creating and persisting a file."""
+
+    def __init__(self, file_repo: FileRepositoryPort, storage: FileStoragePort) -> None:
+        self._file_repo = file_repo
+        self._storage = storage
+
+    def execute(
+        self,
+        id_value: str,
+        owner_id_value: str,
+        name: str,
+        content: bytes,
+        directory_id_value: str | None = None,
+    ) -> Result[StoredFile, str]:
+        owner_result = UserId.try_create(owner_id_value)
+        if owner_result.is_err():
+            return Err(owner_result.err() or "Invalid owner id")
+        owner_id = owner_result.ok()
+        assert owner_id is not None
+
+        directory_id = None
+        if directory_id_value is not None:
+            dir_result = DirectoryId.try_create(directory_id_value)
+            if dir_result.is_err():
+                return Err(dir_result.err() or "Invalid directory id")
+            directory_id = dir_result.ok()
+            assert directory_id is not None
+
+        file_result = StoredFile.try_create(id_value, owner_id, name, directory_id)
+        if file_result.is_err():
+            return Err(file_result.err() or "Invalid file data")
+        file = file_result.ok()
+        assert file is not None
+
+        repo_result = self._file_repo.add(file)
+        if repo_result.is_err():
+            return Err(repo_result.err() or "Failed to save file metadata")
+
+        storage_result = self._storage.save(file, content)
+        if storage_result.is_err():
+            return Err(storage_result.err() or "Failed to store file")
+
+        return Ok(file)

--- a/src/codebase_to_llm/application/uc_delete_directory.py
+++ b/src/codebase_to_llm/application/uc_delete_directory.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import DirectoryStructureRepositoryPort
+from codebase_to_llm.domain.directory import DirectoryId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class DeleteDirectoryUseCase:
+    """Use case for deleting a directory."""
+
+    def __init__(self, repo: DirectoryStructureRepositoryPort) -> None:
+        self._repo = repo
+
+    def execute(self, owner_id_value: str, id_value: str) -> Result[None, str]:
+        owner_res = UserId.try_create(owner_id_value)
+        if owner_res.is_err():
+            return Err(owner_res.err() or "Invalid owner id")
+        owner_id = owner_res.ok()
+        assert owner_id is not None
+
+        dir_id_result = DirectoryId.try_create(id_value)
+        if dir_id_result.is_err():
+            return Err(dir_id_result.err() or "Invalid directory id")
+        dir_id = dir_id_result.ok()
+        assert dir_id is not None
+
+        dir_result = self._repo.get(dir_id)
+        if dir_result.is_err():
+            return Err(dir_result.err() or "Directory not found")
+        directory = dir_result.ok()
+        assert directory is not None
+        if directory.owner_id().value() != owner_id.value():
+            return Err("Access denied")
+
+        delete_result = self._repo.remove(dir_id)
+        if delete_result.is_err():
+            return Err(delete_result.err() or "Failed to delete directory")
+
+        return Ok(None)

--- a/src/codebase_to_llm/application/uc_delete_file.py
+++ b/src/codebase_to_llm/application/uc_delete_file.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FileRepositoryPort, FileStoragePort
+from codebase_to_llm.domain.stored_file import StoredFileId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class DeleteFileUseCase:
+    """Use case for deleting a file and its content."""
+
+    def __init__(self, file_repo: FileRepositoryPort, storage: FileStoragePort) -> None:
+        self._file_repo = file_repo
+        self._storage = storage
+
+    def execute(self, owner_id_value: str, file_id_value: str) -> Result[None, str]:
+        owner_res = UserId.try_create(owner_id_value)
+        if owner_res.is_err():
+            return Err(owner_res.err() or "Invalid owner id")
+        owner_id = owner_res.ok()
+        assert owner_id is not None
+
+        id_result = StoredFileId.try_create(file_id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid file id")
+        file_id = id_result.ok()
+        assert file_id is not None
+
+        file_result = self._file_repo.get(file_id)
+        if file_result.is_err():
+            return Err(file_result.err() or "File not found")
+        file = file_result.ok()
+        assert file is not None
+        if file.owner_id().value() != owner_id.value():
+            return Err("Access denied")
+
+        delete_storage = self._storage.delete(file)
+        if delete_storage.is_err():
+            return Err(delete_storage.err() or "Failed to delete file contents")
+
+        delete_repo = self._file_repo.remove(file_id)
+        if delete_repo.is_err():
+            return Err(delete_repo.err() or "Failed to delete file metadata")
+
+        return Ok(None)

--- a/src/codebase_to_llm/application/uc_get_directory.py
+++ b/src/codebase_to_llm/application/uc_get_directory.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import DirectoryStructureRepositoryPort
+from codebase_to_llm.domain.directory import DirectoryId, Directory
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class GetDirectoryUseCase:
+    """Use case for retrieving a directory."""
+
+    def __init__(self, repo: DirectoryStructureRepositoryPort) -> None:
+        self._repo = repo
+
+    def execute(self, owner_id_value: str, id_value: str) -> Result[Directory, str]:
+        owner_res = UserId.try_create(owner_id_value)
+        if owner_res.is_err():
+            return Err(owner_res.err() or "Invalid owner id")
+        owner_id = owner_res.ok()
+        assert owner_id is not None
+
+        dir_id_result = DirectoryId.try_create(id_value)
+        if dir_id_result.is_err():
+            return Err(dir_id_result.err() or "Invalid directory id")
+        dir_id = dir_id_result.ok()
+        assert dir_id is not None
+
+        result = self._repo.get(dir_id)
+        if result.is_err():
+            return Err(result.err() or "Directory not found")
+        directory = result.ok()
+        assert directory is not None
+        if directory.owner_id().value() != owner_id.value():
+            return Err("Access denied")
+        return Ok(directory)

--- a/src/codebase_to_llm/application/uc_get_file.py
+++ b/src/codebase_to_llm/application/uc_get_file.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FileRepositoryPort, FileStoragePort
+from codebase_to_llm.domain.stored_file import StoredFileId, StoredFile
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class GetFileUseCase:
+    """Use case for retrieving a file and its content."""
+
+    def __init__(self, file_repo: FileRepositoryPort, storage: FileStoragePort) -> None:
+        self._file_repo = file_repo
+        self._storage = storage
+
+    def execute(
+        self, owner_id_value: str, file_id_value: str
+    ) -> Result[tuple[StoredFile, bytes], str]:
+        owner_res = UserId.try_create(owner_id_value)
+        if owner_res.is_err():
+            return Err(owner_res.err() or "Invalid owner id")
+        owner_id = owner_res.ok()
+        assert owner_id is not None
+
+        id_result = StoredFileId.try_create(file_id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid file id")
+        file_id = id_result.ok()
+        assert file_id is not None
+
+        file_result = self._file_repo.get(file_id)
+        if file_result.is_err():
+            return Err(file_result.err() or "File not found")
+        file = file_result.ok()
+        assert file is not None
+        if file.owner_id().value() != owner_id.value():
+            return Err("Access denied")
+
+        content_result = self._storage.load(file)
+        if content_result.is_err():
+            return Err(content_result.err() or "Failed to load file content")
+        content = content_result.ok()
+        assert content is not None
+
+        return Ok((file, content))

--- a/src/codebase_to_llm/application/uc_update_directory.py
+++ b/src/codebase_to_llm/application/uc_update_directory.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import DirectoryStructureRepositoryPort
+from codebase_to_llm.domain.directory import DirectoryId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class UpdateDirectoryUseCase:
+    """Use case for renaming or moving a directory."""
+
+    def __init__(self, repo: DirectoryStructureRepositoryPort) -> None:
+        self._repo = repo
+
+    def execute(
+        self,
+        owner_id_value: str,
+        id_value: str,
+        new_name: str | None = None,
+        new_parent_id_value: str | None = None,
+    ) -> Result[None, str]:
+        owner_res = UserId.try_create(owner_id_value)
+        if owner_res.is_err():
+            return Err(owner_res.err() or "Invalid owner id")
+        owner_id = owner_res.ok()
+        assert owner_id is not None
+
+        dir_id_result = DirectoryId.try_create(id_value)
+        if dir_id_result.is_err():
+            return Err(dir_id_result.err() or "Invalid directory id")
+        dir_id = dir_id_result.ok()
+        assert dir_id is not None
+
+        dir_result = self._repo.get(dir_id)
+        if dir_result.is_err():
+            return Err(dir_result.err() or "Directory not found")
+        directory = dir_result.ok()
+        assert directory is not None
+        if directory.owner_id().value() != owner_id.value():
+            return Err("Access denied")
+
+        updated = directory
+        if new_name is not None:
+            rename_result = directory.rename(new_name)
+            if rename_result.is_err():
+                return Err(rename_result.err() or "Invalid directory name")
+            renamed = rename_result.ok()
+            assert renamed is not None
+            updated = renamed
+
+        if new_parent_id_value is not None:
+            parent_result = DirectoryId.try_create(new_parent_id_value)
+            if parent_result.is_err():
+                return Err(parent_result.err() or "Invalid parent id")
+            parent_id = parent_result.ok()
+            assert parent_id is not None
+            updated = updated.move(parent_id)
+
+        update_result = self._repo.update(updated)
+        if update_result.is_err():
+            return Err(update_result.err() or "Failed to update directory")
+
+        return Ok(None)

--- a/src/codebase_to_llm/application/uc_update_file.py
+++ b/src/codebase_to_llm/application/uc_update_file.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import FileRepositoryPort
+from codebase_to_llm.domain.stored_file import StoredFileId
+from codebase_to_llm.domain.directory import DirectoryId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+class UpdateFileUseCase:
+    """Use case for renaming or moving a file."""
+
+    def __init__(self, file_repo: FileRepositoryPort) -> None:
+        self._file_repo = file_repo
+
+    def execute(
+        self,
+        owner_id_value: str,
+        file_id_value: str,
+        new_name: str | None = None,
+        new_directory_id_value: str | None = None,
+    ) -> Result[None, str]:
+        owner_res = UserId.try_create(owner_id_value)
+        if owner_res.is_err():
+            return Err(owner_res.err() or "Invalid owner id")
+        owner_id = owner_res.ok()
+        assert owner_id is not None
+
+        id_result = StoredFileId.try_create(file_id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid file id")
+        file_id = id_result.ok()
+        assert file_id is not None
+
+        file_result = self._file_repo.get(file_id)
+        if file_result.is_err():
+            return Err(file_result.err() or "File not found")
+        file = file_result.ok()
+        assert file is not None
+
+        if file.owner_id().value() != owner_id.value():
+            return Err("Access denied")
+
+        updated = file
+        if new_name is not None:
+            rename_result = file.rename(new_name)
+            if rename_result.is_err():
+                return Err(rename_result.err() or "Invalid file name")
+            renamed = rename_result.ok()
+            assert renamed is not None
+            updated = renamed
+
+        if new_directory_id_value is not None:
+            dir_result = DirectoryId.try_create(new_directory_id_value)
+            if dir_result.is_err():
+                return Err(dir_result.err() or "Invalid directory id")
+            new_dir = dir_result.ok()
+            assert new_dir is not None
+            updated = updated.move(new_dir)
+
+        update_result = self._file_repo.update(updated)
+        if update_result.is_err():
+            return Err(update_result.err() or "Failed to update file")
+
+        return Ok(None)

--- a/src/codebase_to_llm/config.py
+++ b/src/codebase_to_llm/config.py
@@ -21,6 +21,7 @@ class AppConfig:
     smtp_password: str
     smtp_sender_name: str
     deployment_url: str
+    gcp_bucket_name: str
 
 
 def load_config() -> AppConfig:
@@ -33,6 +34,7 @@ def load_config() -> AppConfig:
         smtp_password=os.getenv("SMTP_PASSWORD", ""),
         smtp_sender_name=os.getenv("SMTP_SENDER_NAME", "CodeToMarket"),
         deployment_url=os.getenv("DEPLOYMENT_URL", "http://localhost:8000"),
+        gcp_bucket_name=os.getenv("GCP_BUCKET_NAME", ""),
     )
 
 

--- a/src/codebase_to_llm/domain/directory.py
+++ b/src/codebase_to_llm/domain/directory.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import final
+
+from .entity import Entity
+from .result import Err, Ok, Result
+from .value_object import ValueObject
+from .user import UserId
+
+
+@final
+class DirectoryId(ValueObject):
+    """Unique identifier for a directory."""
+
+    __slots__ = ("_value",)
+    _value: str
+
+    @staticmethod
+    def try_create(value: str) -> Result["DirectoryId", str]:
+        trimmed = value.strip()
+        if not trimmed:
+            return Err("Directory id cannot be empty.")
+        return Ok(DirectoryId(trimmed))
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return self._value
+
+
+@final
+class Directory(Entity):
+    """Directory owned by a user."""
+
+    __slots__ = ("_owner_id", "_parent_id", "_name")
+    _owner_id: UserId
+    _parent_id: Optional[DirectoryId]
+    _name: str
+
+    @staticmethod
+    def try_create(
+        id_value: str,
+        owner_id: UserId,
+        name: str,
+        parent_id: Optional[DirectoryId] = None,
+    ) -> Result["Directory", str]:
+        id_result = DirectoryId.try_create(id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid directory id.")
+        trimmed_name = name.strip()
+        if not trimmed_name:
+            return Err("Directory name cannot be empty.")
+        id_obj = id_result.ok()
+        assert id_obj is not None
+        return Ok(Directory(id_obj, owner_id, parent_id, trimmed_name))
+
+    def __init__(
+        self,
+        id: DirectoryId,
+        owner_id: UserId,
+        parent_id: Optional[DirectoryId],
+        name: str,
+    ) -> None:
+        super().__init__(id)
+        self._owner_id = owner_id
+        self._parent_id = parent_id
+        self._name = name
+
+    def owner_id(self) -> UserId:
+        return self._owner_id
+
+    def parent_id(self) -> Optional[DirectoryId]:
+        return self._parent_id
+
+    def name(self) -> str:
+        return self._name
+
+    def rename(self, new_name: str) -> Result["Directory", str]:
+        trimmed = new_name.strip()
+        if not trimmed:
+            return Err("Directory name cannot be empty.")
+        return Ok(Directory(self.id(), self._owner_id, self._parent_id, trimmed))
+
+    def move(self, new_parent_id: Optional[DirectoryId]) -> "Directory":
+        return Directory(self.id(), self._owner_id, new_parent_id, self._name)

--- a/src/codebase_to_llm/domain/entity.py
+++ b/src/codebase_to_llm/domain/entity.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class Entity:
+    """Base class for entities compared by identity."""
+
+    __slots__ = ("_id",)
+    _id: Any
+
+    def __init__(self, id: Any) -> None:
+        self._id = id
+
+    def id(self) -> Any:
+        return self._id
+
+    def __eq__(self, other: object) -> bool:  # noqa: D401 - simple verb
+        return isinstance(other, Entity) and self._id == other._id
+
+    def __hash__(self) -> int:  # noqa: D401 - simple verb
+        return hash(self._id)

--- a/src/codebase_to_llm/domain/stored_file.py
+++ b/src/codebase_to_llm/domain/stored_file.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import final
+
+from .entity import Entity
+from .result import Err, Ok, Result
+from .value_object import ValueObject
+from .user import UserId
+from .directory import DirectoryId
+
+
+@final
+class StoredFileId(ValueObject):
+    """Unique identifier for a stored file."""
+
+    __slots__ = ("_value",)
+    _value: str
+
+    @staticmethod
+    def try_create(value: str) -> Result["StoredFileId", str]:
+        trimmed = value.strip()
+        if not trimmed:
+            return Err("File id cannot be empty.")
+        return Ok(StoredFileId(trimmed))
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return self._value
+
+
+@final
+class StoredFile(Entity):
+    """File metadata owned by a user."""
+
+    __slots__ = ("_owner_id", "_directory_id", "_name")
+    _owner_id: UserId
+    _directory_id: Optional[DirectoryId]
+    _name: str
+
+    @staticmethod
+    def try_create(
+        id_value: str,
+        owner_id: UserId,
+        name: str,
+        directory_id: Optional[DirectoryId] = None,
+    ) -> Result["StoredFile", str]:
+        id_result = StoredFileId.try_create(id_value)
+        if id_result.is_err():
+            return Err(id_result.err() or "Invalid file id.")
+        trimmed_name = name.strip()
+        if not trimmed_name:
+            return Err("File name cannot be empty.")
+        id_obj = id_result.ok()
+        assert id_obj is not None
+        return Ok(StoredFile(id_obj, owner_id, directory_id, trimmed_name))
+
+    def __init__(
+        self,
+        id: StoredFileId,
+        owner_id: UserId,
+        directory_id: Optional[DirectoryId],
+        name: str,
+    ) -> None:
+        super().__init__(id)
+        self._owner_id = owner_id
+        self._directory_id = directory_id
+        self._name = name
+
+    def owner_id(self) -> UserId:
+        return self._owner_id
+
+    def directory_id(self) -> Optional[DirectoryId]:
+        return self._directory_id
+
+    def name(self) -> str:
+        return self._name
+
+    def rename(self, new_name: str) -> Result["StoredFile", str]:
+        trimmed = new_name.strip()
+        if not trimmed:
+            return Err("File name cannot be empty.")
+        return Ok(StoredFile(self.id(), self._owner_id, self._directory_id, trimmed))
+
+    def move(self, new_directory_id: Optional[DirectoryId]) -> "StoredFile":
+        return StoredFile(self.id(), self._owner_id, new_directory_id, self._name)

--- a/src/codebase_to_llm/infrastructure/gcp_file_storage.py
+++ b/src/codebase_to_llm/infrastructure/gcp_file_storage.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import final
+
+from codebase_to_llm.application.ports import FileStoragePort
+from codebase_to_llm.domain.stored_file import StoredFile
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.config import CONFIG
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from google.cloud import storage  # type: ignore[import-not-found]
+
+
+@final
+class GCPFileStorage(FileStoragePort):
+    """Store files in a Google Cloud Storage bucket."""
+
+    __slots__ = ("_bucket_name",)
+    _bucket_name: str
+
+    def __init__(self, bucket_name: str | None = None) -> None:
+        self._bucket_name = bucket_name or CONFIG.gcp_bucket_name
+
+    def _client(self) -> "storage.Client":  # pragma: no cover - network
+        from google.cloud import storage
+
+        return storage.Client()
+
+    def save(self, file: StoredFile, content: bytes) -> Result[None, str]:
+        try:
+            client = self._client()
+            bucket = client.bucket(self._bucket_name)
+            blob = bucket.blob(file.id().value())
+            blob.upload_from_string(content)
+            return Ok(None)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+
+    def load(self, file: StoredFile) -> Result[bytes, str]:
+        try:
+            client = self._client()
+            bucket = client.bucket(self._bucket_name)
+            blob = bucket.blob(file.id().value())
+            data = blob.download_as_bytes()
+            return Ok(data)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+
+    def delete(self, file: StoredFile) -> Result[None, str]:
+        try:
+            client = self._client()
+            bucket = client.bucket(self._bucket_name)
+            blob = bucket.blob(file.id().value())
+            blob.delete()
+            return Ok(None)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_directory_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_directory_repository.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+from typing_extensions import final
+from sqlalchemy import Column, String, Table
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from codebase_to_llm.application.ports import DirectoryStructureRepositoryPort
+from codebase_to_llm.domain.directory import Directory, DirectoryId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.infrastructure.db import DatabaseSessionManager, get_metadata
+
+_directories_table = Table(
+    "directories",
+    get_metadata(),
+    Column("id", String, primary_key=True),
+    Column("user_id", String, nullable=False),
+    Column("parent_id", String, nullable=True),
+    Column("name", String, nullable=False),
+)
+
+
+@final
+class SqlAlchemyDirectoryRepository(DirectoryStructureRepositoryPort):
+    """Directory repository backed by PostgreSQL."""
+
+    __slots__ = ()
+
+    def _session(self) -> Session:
+        return DatabaseSessionManager.get_session()
+
+    def add(self, directory: Directory) -> Result[None, str]:
+        session = self._session()
+        try:
+            parent = directory.parent_id()
+            session.execute(
+                _directories_table.insert().values(
+                    id=directory.id().value(),
+                    user_id=directory.owner_id().value(),
+                    parent_id=parent.value() if parent is not None else None,
+                    name=directory.name(),
+                )
+            )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def get(self, directory_id: DirectoryId) -> Result[Directory, str]:
+        session = self._session()
+        try:
+            row = session.execute(
+                _directories_table.select().where(
+                    _directories_table.c.id == directory_id.value()
+                )
+            ).fetchone()
+            if row is None:
+                return Err("Directory not found")
+            owner_res = UserId.try_create(row.user_id)
+            if owner_res.is_err():
+                return Err("Invalid user id in database")
+            owner_id = owner_res.ok()
+            assert owner_id is not None
+            parent_id = None
+            if row.parent_id is not None:
+                parent_res = DirectoryId.try_create(row.parent_id)
+                if parent_res.is_err():
+                    return Err("Invalid parent id in database")
+                parent_id = parent_res.ok()
+                assert parent_id is not None
+            dir_res = Directory.try_create(row.id, owner_id, row.name, parent_id)
+            if dir_res.is_err():
+                return Err(dir_res.err() or "Invalid directory data")
+            directory = dir_res.ok()
+            assert directory is not None
+            return Ok(directory)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def update(self, directory: Directory) -> Result[None, str]:
+        session = self._session()
+        try:
+            parent = directory.parent_id()
+            session.execute(
+                _directories_table.update()
+                .where(_directories_table.c.id == directory.id().value())
+                .values(
+                    user_id=directory.owner_id().value(),
+                    parent_id=parent.value() if parent is not None else None,
+                    name=directory.name(),
+                )
+            )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def remove(self, directory_id: DirectoryId) -> Result[None, str]:
+        session = self._session()
+        try:
+            session.execute(
+                _directories_table.delete().where(
+                    _directories_table.c.id == directory_id.value()
+                )
+            )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))

--- a/src/codebase_to_llm/infrastructure/sqlalchemy_file_repository.py
+++ b/src/codebase_to_llm/infrastructure/sqlalchemy_file_repository.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+from typing_extensions import final
+from sqlalchemy import Column, String, Table
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from codebase_to_llm.application.ports import FileRepositoryPort
+from codebase_to_llm.domain.stored_file import StoredFile, StoredFileId
+from codebase_to_llm.domain.directory import DirectoryId
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.result import Result, Ok, Err
+from codebase_to_llm.infrastructure.db import DatabaseSessionManager, get_metadata
+
+_files_table = Table(
+    "files",
+    get_metadata(),
+    Column("id", String, primary_key=True),
+    Column("user_id", String, nullable=False),
+    Column("directory_id", String, nullable=True),
+    Column("name", String, nullable=False),
+)
+
+
+@final
+class SqlAlchemyFileRepository(FileRepositoryPort):
+    """File metadata repository backed by PostgreSQL."""
+
+    __slots__ = ()
+
+    def _session(self) -> Session:
+        return DatabaseSessionManager.get_session()
+
+    def add(self, file: StoredFile) -> Result[None, str]:
+        session = self._session()
+        try:
+            dir_id = file.directory_id()
+            session.execute(
+                _files_table.insert().values(
+                    id=file.id().value(),
+                    user_id=file.owner_id().value(),
+                    directory_id=dir_id.value() if dir_id is not None else None,
+                    name=file.name(),
+                )
+            )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def get(self, file_id: StoredFileId) -> Result[StoredFile, str]:
+        session = self._session()
+        try:
+            row = session.execute(
+                _files_table.select().where(_files_table.c.id == file_id.value())
+            ).fetchone()
+            if row is None:
+                return Err("File not found")
+            owner_res = UserId.try_create(row.user_id)
+            if owner_res.is_err():
+                return Err("Invalid user id in database")
+            owner_id = owner_res.ok()
+            assert owner_id is not None
+            directory_id = None
+            if row.directory_id is not None:
+                dir_res = DirectoryId.try_create(row.directory_id)
+                if dir_res.is_err():
+                    return Err("Invalid directory id in database")
+                directory_id = dir_res.ok()
+                assert directory_id is not None
+            file_res = StoredFile.try_create(row.id, owner_id, row.name, directory_id)
+            if file_res.is_err():
+                return Err(file_res.err() or "Invalid file data")
+            file = file_res.ok()
+            assert file is not None
+            return Ok(file)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def update(self, file: StoredFile) -> Result[None, str]:
+        session = self._session()
+        try:
+            dir_id = file.directory_id()
+            session.execute(
+                _files_table.update()
+                .where(_files_table.c.id == file.id().value())
+                .values(
+                    user_id=file.owner_id().value(),
+                    directory_id=dir_id.value() if dir_id is not None else None,
+                    name=file.name(),
+                )
+            )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))
+
+    def remove(self, file_id: StoredFileId) -> Result[None, str]:
+        session = self._session()
+        try:
+            session.execute(
+                _files_table.delete().where(_files_table.c.id == file_id.value())
+            )
+            session.commit()
+            return Ok(None)
+        except SQLAlchemyError as exc:  # noqa: BLE001
+            session.rollback()
+            logging.warning(str(exc))
+            return Err(str(exc))

--- a/src/codebase_to_llm/interface/http_api.py
+++ b/src/codebase_to_llm/interface/http_api.py
@@ -78,6 +78,14 @@ from codebase_to_llm.application.uc_add_rule import AddRuleUseCase
 from codebase_to_llm.application.uc_get_rules import GetRulesUseCase
 from codebase_to_llm.application.uc_update_rule import UpdateRuleUseCase
 from codebase_to_llm.application.uc_remove_rule import RemoveRuleUseCase
+from codebase_to_llm.application.uc_add_file import AddFileUseCase
+from codebase_to_llm.application.uc_get_file import GetFileUseCase
+from codebase_to_llm.application.uc_update_file import UpdateFileUseCase
+from codebase_to_llm.application.uc_delete_file import DeleteFileUseCase
+from codebase_to_llm.application.uc_add_directory import AddDirectoryUseCase
+from codebase_to_llm.application.uc_get_directory import GetDirectoryUseCase
+from codebase_to_llm.application.uc_update_directory import UpdateDirectoryUseCase
+from codebase_to_llm.application.uc_delete_directory import DeleteDirectoryUseCase
 from codebase_to_llm.domain.api_key import ApiKeyId
 from codebase_to_llm.application.uc_register_user import RegisterUserUseCase
 from codebase_to_llm.application.uc_authenticate_user import AuthenticateUserUseCase
@@ -113,6 +121,13 @@ from codebase_to_llm.infrastructure.sqlalchemy_user_repository import (
     SqlAlchemyUserRepository,
 )
 from codebase_to_llm.infrastructure.brevo_email_sender import BrevoEmailSender
+from codebase_to_llm.infrastructure.sqlalchemy_file_repository import (
+    SqlAlchemyFileRepository,
+)
+from codebase_to_llm.infrastructure.sqlalchemy_directory_repository import (
+    SqlAlchemyDirectoryRepository,
+)
+from codebase_to_llm.infrastructure.gcp_file_storage import GCPFileStorage
 
 # Load environment variables from .env-development file
 load_dotenv(".env-development")
@@ -197,6 +212,9 @@ _directory_repo = FileSystemDirectoryRepository(Path.cwd())
 _llm_adapter = OpenAILLMAdapter()
 _user_repo = SqlAlchemyUserRepository()
 _email_sender = BrevoEmailSender()
+_file_repo = SqlAlchemyFileRepository()
+_directory_structure_repo = SqlAlchemyDirectoryRepository()
+_file_storage = GCPFileStorage()
 
 
 def get_user_repositories(user: User) -> tuple[
@@ -881,3 +899,165 @@ def copy_context(
     if result.is_err():
         raise HTTPException(status_code=400, detail=result.err())
     return {"content": _clipboard.text()}
+
+
+class UploadFileRequest(BaseModel):
+    id_value: str
+    name: str
+    content: str
+    directory_id: str | None = None
+
+
+@app.post("/files")
+def upload_file(
+    request: UploadFileRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, str]:
+    use_case = AddFileUseCase(_file_repo, _file_storage)
+    result = use_case.execute(
+        request.id_value,
+        current_user.id().value(),
+        request.name,
+        request.content.encode("utf-8"),
+        request.directory_id,
+    )
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    file = result.ok()
+    assert file is not None
+    return {"id": file.id().value(), "name": file.name()}
+
+
+@app.get("/files/{file_id}")
+def get_file(
+    file_id: str, current_user: Annotated[User, Depends(get_current_user)]
+) -> dict[str, str | None]:
+    use_case = GetFileUseCase(_file_repo, _file_storage)
+    result = use_case.execute(current_user.id().value(), file_id)
+    if result.is_err():
+        raise HTTPException(status_code=404, detail=result.err())
+    file, content = result.ok() or (None, b"")
+    assert file is not None
+    dir_id = file.directory_id()
+    return {
+        "id": file.id().value(),
+        "name": file.name(),
+        "directory_id": dir_id.value() if dir_id is not None else None,
+        "content": content.decode("utf-8"),
+    }
+
+
+class UpdateFileRequest(BaseModel):
+    new_name: str | None = None
+    new_directory_id: str | None = None
+
+
+@app.put("/files/{file_id}")
+def update_file(
+    file_id: str,
+    request: UpdateFileRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, str]:
+    use_case = UpdateFileUseCase(_file_repo)
+    result = use_case.execute(
+        current_user.id().value(),
+        file_id,
+        request.new_name,
+        request.new_directory_id,
+    )
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    return {"status": "updated"}
+
+
+@app.delete("/files/{file_id}")
+def delete_file(
+    file_id: str, current_user: Annotated[User, Depends(get_current_user)]
+) -> dict[str, str]:
+    use_case = DeleteFileUseCase(_file_repo, _file_storage)
+    result = use_case.execute(current_user.id().value(), file_id)
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    return {"status": "deleted"}
+
+
+class CreateDirectoryRequest(BaseModel):
+    id_value: str
+    name: str
+    parent_id: str | None = None
+
+
+@app.post("/directories")
+def create_directory(
+    request: CreateDirectoryRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, str | None]:
+    use_case = AddDirectoryUseCase(_directory_structure_repo)
+    result = use_case.execute(
+        request.id_value,
+        current_user.id().value(),
+        request.name,
+        request.parent_id,
+    )
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    directory = result.ok()
+    assert directory is not None
+    parent = directory.parent_id()
+    return {
+        "id": directory.id().value(),
+        "name": directory.name(),
+        "parent_id": parent.value() if parent is not None else None,
+    }
+
+
+@app.get("/directories/{directory_id}")
+def get_directory(
+    directory_id: str, current_user: Annotated[User, Depends(get_current_user)]
+) -> dict[str, str | None]:
+    use_case = GetDirectoryUseCase(_directory_structure_repo)
+    result = use_case.execute(current_user.id().value(), directory_id)
+    if result.is_err():
+        raise HTTPException(status_code=404, detail=result.err())
+    directory = result.ok()
+    assert directory is not None
+    parent = directory.parent_id()
+    return {
+        "id": directory.id().value(),
+        "name": directory.name(),
+        "parent_id": parent.value() if parent is not None else None,
+    }
+
+
+class UpdateDirectoryRequest(BaseModel):
+    new_name: str | None = None
+    new_parent_id: str | None = None
+
+
+@app.put("/directories/{directory_id}")
+def update_directory(
+    directory_id: str,
+    request: UpdateDirectoryRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, str]:
+    use_case = UpdateDirectoryUseCase(_directory_structure_repo)
+    result = use_case.execute(
+        current_user.id().value(),
+        directory_id,
+        request.new_name,
+        request.new_parent_id,
+    )
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    return {"status": "updated"}
+
+
+@app.delete("/directories/{directory_id}")
+def delete_directory(
+    directory_id: str, current_user: Annotated[User, Depends(get_current_user)]
+) -> dict[str, str]:
+    use_case = DeleteDirectoryUseCase(_directory_structure_repo)
+    result = use_case.execute(current_user.id().value(), directory_id)
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    return {"status": "deleted"}


### PR DESCRIPTION
## Summary
- model immutable `StoredFile` and `Directory` entities with base `Entity`
- add repository and storage ports and GCP/PostgreSQL adapters for files and directories
- expose CRUD HTTP endpoints for managing user files and directories
- configure bucket name via `GCP_BUCKET_NAME` and include migrations for new tables

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`


------
https://chatgpt.com/codex/tasks/task_e_68999295638483328673a610de80253e