### PR TITLE
Add video translation task queue and API

### DIFF
--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -2,4 +2,4 @@
 set -e
 
 echo "Starting Celery worker..."
-exec uv run celery -A codebase_to_llm.infrastructure.celery_download_queue worker --loglevel=info
+exec uv run celery -A codebase_to_llm.infrastructure.celery_app worker --loglevel=info

--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -267,10 +267,10 @@ class TranslationTaskPort(Protocol):
 
     def enqueue_translation(
         self,
-        file_id: str | None,
-        youtube_url: str | None,
+        file_id: str,
         target_language: str,
         owner_id: str,
+        output_filename: str,
     ) -> Result[str, str]: ...  # pragma: no cover
 
     def get_task_status(

--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -260,3 +260,19 @@ class DownloadTaskPort(Protocol):
     def get_task_status(
         self, task_id: str
     ) -> Result[tuple[str, str | None], str]: ...  # pragma: no cover
+
+
+class TranslationTaskPort(Protocol):
+    """Port for long-running translation tasks."""
+
+    def enqueue_translation(
+        self,
+        file_id: str | None,
+        youtube_url: str | None,
+        target_language: str,
+        owner_id: str,
+    ) -> Result[str, str]: ...  # pragma: no cover
+
+    def get_task_status(
+        self, task_id: str
+    ) -> Result[tuple[str, str | None], str]: ...  # pragma: no cover

--- a/src/codebase_to_llm/application/uc_translate_video.py
+++ b/src/codebase_to_llm/application/uc_translate_video.py
@@ -5,14 +5,14 @@ from codebase_to_llm.domain.result import Result
 
 
 def enqueue_video_translation(
-    file_id: str | None,
-    youtube_url: str | None,
+    file_id: str,
     target_language: str,
     owner_id: str,
+    output_filename: str,
     task_port: TranslationTaskPort,
 ) -> Result[str, str]:
     return task_port.enqueue_translation(
-        file_id, youtube_url, target_language, owner_id
+        file_id, target_language, owner_id, output_filename
     )
 
 

--- a/src/codebase_to_llm/application/uc_translate_video.py
+++ b/src/codebase_to_llm/application/uc_translate_video.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import TranslationTaskPort
+from codebase_to_llm.domain.result import Result
+
+
+def enqueue_video_translation(
+    file_id: str | None,
+    youtube_url: str | None,
+    target_language: str,
+    owner_id: str,
+    task_port: TranslationTaskPort,
+) -> Result[str, str]:
+    return task_port.enqueue_translation(
+        file_id, youtube_url, target_language, owner_id
+    )
+
+
+def get_translation_status(
+    task_id: str, task_port: TranslationTaskPort
+) -> Result[tuple[str, str | None], str]:
+    return task_port.get_task_status(task_id)

--- a/src/codebase_to_llm/infrastructure/celery_app.py
+++ b/src/codebase_to_llm/infrastructure/celery_app.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from celery import Celery
+from codebase_to_llm.config import CONFIG
+
+# Create the main Celery app
+celery_app = Celery(
+    "codebase_to_llm",
+    broker=CONFIG.redis_url,
+    backend=CONFIG.redis_url,
+)
+
+# Configure Celery
+celery_app.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    timezone="UTC",
+    enable_utc=True,
+)
+
+# Import task modules to register tasks (must be after app creation)
+# This will register the tasks with the celery_app instance
+try:
+    import codebase_to_llm.infrastructure.celery_download_queue  # noqa: F401
+    import codebase_to_llm.infrastructure.celery_translation_queue  # noqa: F401
+except ImportError as e:
+    # Log the error but don't fail - some tasks might not be available in all environments
+    import logging
+
+    logging.getLogger(__name__).warning(f"Could not import task modules: {e}")

--- a/src/codebase_to_llm/infrastructure/celery_download_queue.py
+++ b/src/codebase_to_llm/infrastructure/celery_download_queue.py
@@ -8,7 +8,6 @@ import tempfile
 import time
 import uuid
 from typing_extensions import final
-from celery import Celery
 
 from codebase_to_llm.application.ports import DownloadTaskPort
 from codebase_to_llm.application.uc_add_file import AddFileUseCase
@@ -17,15 +16,9 @@ from codebase_to_llm.infrastructure.gcp_file_storage import GCPFileStorage
 from codebase_to_llm.infrastructure.sqlalchemy_file_repository import (
     SqlAlchemyFileRepository,
 )
-from codebase_to_llm.config import CONFIG
+from codebase_to_llm.infrastructure.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
-
-celery_app = Celery(
-    "downloader",
-    broker=CONFIG.redis_url,
-    backend=CONFIG.redis_url,
-)
 
 
 def sanitize_filename(name: str, replacement: str = "_", max_length: int = 255) -> str:

--- a/src/codebase_to_llm/infrastructure/celery_translation_queue.py
+++ b/src/codebase_to_llm/infrastructure/celery_translation_queue.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import uuid
+from typing_extensions import final
+from celery import Celery
+from openai import OpenAI
+
+from codebase_to_llm.application.ports import TranslationTaskPort
+from codebase_to_llm.application.uc_add_file import AddFileUseCase
+from codebase_to_llm.domain.result import Err, Ok, Result
+from codebase_to_llm.domain.stored_file import StoredFileId
+from codebase_to_llm.infrastructure.gcp_file_storage import GCPFileStorage
+from codebase_to_llm.infrastructure.sqlalchemy_file_repository import (
+    SqlAlchemyFileRepository,
+)
+from codebase_to_llm.config import CONFIG
+
+logger = logging.getLogger(__name__)
+
+celery_app = Celery(
+    "translator",
+    broker=CONFIG.redis_url,
+    backend=CONFIG.redis_url,
+)
+
+
+def parse_srt(srt_content: str) -> list[dict[str, str | int]]:
+    pattern = r"(\d+)\n(\d{2}:\d{2}:\d{2},\d{3}) --> (\d{2}:\d{2}:\d{2},\d{3})\n(.*?)(?=\n\d+\n|\n*$)"
+    matches = re.findall(pattern, srt_content, re.DOTALL)
+    subtitles: list[dict[str, str | int]] = []
+    for match in matches:
+        subtitles.append(
+            {
+                "index": int(match[0]),
+                "start": match[1],
+                "end": match[2],
+                "text": match[3].strip(),
+            }
+        )
+    return subtitles
+
+
+def format_srt(subtitles: list[dict[str, str | int]]) -> str:
+    srt_content = ""
+    for sub in subtitles:
+        idx = sub["index"]
+        start = sub["start"]
+        end = sub["end"]
+        text = sub["text"]
+        srt_content += f"{idx}\n{start} --> {end}\n{text}\n\n"
+    return srt_content
+
+
+def translate_text(client: OpenAI, text: str, target_language: str) -> str:
+    language_names = {
+        "fr": "French",
+        "es": "Spanish",
+        "de": "German",
+        "it": "Italian",
+        "pt": "Portuguese",
+        "ru": "Russian",
+        "ja": "Japanese",
+        "ko": "Korean",
+        "zh": "Chinese",
+        "ar": "Arabic",
+    }
+    target_lang_name = language_names.get(target_language, target_language)
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a professional translator. Translate the following text to "
+                    f"{target_lang_name}. Maintain the original meaning and tone. Only return the translated text, nothing else."
+                ),
+            },
+            {"role": "user", "content": text},
+        ],
+        temperature=0.3,
+    )
+    content = response.choices[0].message.content
+    assert content is not None
+    return content.strip()
+
+
+def sanitize_filename(name: str, replacement: str = "_", max_length: int = 255) -> str:
+    name = str(name).strip()
+    name = re.sub(r'[<>:"/\\|?*\x00-\x1F]', replacement, name)
+    name = name.rstrip(" .")
+    if replacement:
+        rep_escaped = re.escape(replacement)
+        name = re.sub(rf"{rep_escaped}+", replacement, name)
+    if not name:
+        name = "untitled"
+    return name[:max_length]
+
+
+def _load_video_from_file(file_id: str) -> Result[bytes, str]:
+    file_repo = SqlAlchemyFileRepository()
+    storage = GCPFileStorage()
+    id_res = StoredFileId.try_create(file_id)
+    if id_res.is_err():
+        return Err(id_res.err() or "Invalid file id")
+    stored_file = id_res.ok()
+    assert stored_file is not None
+    file_res = file_repo.get(stored_file)
+    if file_res.is_err():
+        return Err(file_res.err() or "File not found")
+    file = file_res.ok()
+    assert file is not None
+    content_res = storage.load(file)
+    if content_res.is_err():
+        return Err(content_res.err() or "Unable to load file content")
+    data = content_res.ok()
+    assert data is not None
+    return Ok(data)
+
+
+def _download_video(url: str, path: str) -> None:
+    subprocess.run(
+        ["yt-dlp", "-f", "mp4", "-o", path, url],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _process_video(content: bytes, target_language: str) -> bytes:
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = OpenAI(api_key=api_key)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video_path = os.path.join(tmpdir, "input.mp4")
+        with open(video_path, "wb") as fh:
+            fh.write(content)
+        audio_path = os.path.join(tmpdir, "audio.wav")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-i",
+                video_path,
+                "-ar",
+                "16000",
+                "-ac",
+                "1",
+                "-c:a",
+                "pcm_s16le",
+                audio_path,
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        with open(audio_path, "rb") as audio_file:
+            transcript = client.audio.transcriptions.create(
+                model="whisper-1", file=audio_file, response_format="srt"
+            )
+        if target_language != "en":
+            subtitles = parse_srt(transcript)
+            for subtitle in subtitles:
+                text = subtitle["text"]
+                assert isinstance(text, str)
+                subtitle["text"] = translate_text(client, text, target_language)
+            transcript = format_srt(subtitles)
+        srt_path = os.path.join(tmpdir, "subtitles.srt")
+        with open(srt_path, "w", encoding="utf-8") as f:
+            f.write(transcript)
+        output_path = os.path.join(tmpdir, "output.mp4")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-i",
+                video_path,
+                "-vf",
+                f"subtitles={srt_path}",
+                "-c:a",
+                "copy",
+                output_path,
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        with open(output_path, "rb") as out_file:
+            return out_file.read()
+
+
+@celery_app.task(name="translate_video")
+def translate_video_task(
+    file_id: str | None,
+    youtube_url: str | None,
+    target_language: str,
+    owner_id: str,
+) -> str:  # pragma: no cover - worker
+    with tempfile.TemporaryDirectory() as tmpdir:
+        if youtube_url is not None:
+            video_path = os.path.join(
+                tmpdir, sanitize_filename(str(uuid.uuid4())) + ".mp4"
+            )
+            _download_video(youtube_url, video_path)
+            with open(video_path, "rb") as fh:
+                content = fh.read()
+        else:
+            if file_id is None:
+                raise Exception("Either file_id or youtube_url must be provided")
+            load_res = _load_video_from_file(file_id)
+            if load_res.is_err():
+                raise Exception(load_res.err())
+            content_opt = load_res.ok()
+            if content_opt is None:
+                raise Exception("Unable to load file")
+            content = content_opt
+        output_bytes = _process_video(content, target_language)
+    new_file_id = str(uuid.uuid4())
+    file_repo = SqlAlchemyFileRepository()
+    storage = GCPFileStorage()
+    add_file_use_case = AddFileUseCase(file_repo, storage)
+    result = add_file_use_case.execute(
+        id_value=new_file_id,
+        owner_id_value=owner_id,
+        name="translated.mp4",
+        content=output_bytes,
+        directory_id_value=None,
+    )
+    if result.is_err():  # pragma: no cover - validation/network
+        raise Exception(result.err())
+    return new_file_id
+
+
+@final
+class CeleryTranslationTaskQueue(TranslationTaskPort):
+    __slots__ = ()
+
+    def enqueue_translation(
+        self,
+        file_id: str | None,
+        youtube_url: str | None,
+        target_language: str,
+        owner_id: str,
+    ) -> Result[str, str]:
+        try:
+            task = translate_video_task.delay(
+                file_id, youtube_url, target_language, owner_id
+            )
+            return Ok(task.id)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+
+    def get_task_status(self, task_id: str) -> Result[tuple[str, str | None], str]:
+        try:
+            async_result = celery_app.AsyncResult(task_id)
+            status = async_result.status
+            if async_result.successful():
+                file_id = str(async_result.get())
+                return Ok((status, file_id))
+            return Ok((status, None))
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))

--- a/src/codebase_to_llm/interface/fastapi/app.py
+++ b/src/codebase_to_llm/interface/fastapi/app.py
@@ -26,6 +26,7 @@ from .directories import router as directories_router
 from .llm import router as llm_router
 from .recent import router as recent_router
 from .downloads import router as downloads_router
+from .translations import router as translations_router
 
 load_dotenv(".env-development")
 
@@ -59,6 +60,7 @@ app.include_router(directories_router)
 app.include_router(llm_router)
 app.include_router(recent_router)
 app.include_router(downloads_router)
+app.include_router(translations_router)
 
 
 @app.post("/register")

--- a/src/codebase_to_llm/interface/fastapi/dependencies.py
+++ b/src/codebase_to_llm/interface/fastapi/dependencies.py
@@ -55,6 +55,9 @@ from codebase_to_llm.infrastructure.logging_metrics_service import (
 from codebase_to_llm.infrastructure.celery_download_queue import (
     CeleryDownloadTaskQueue,
 )
+from codebase_to_llm.infrastructure.celery_translation_queue import (
+    CeleryTranslationTaskQueue,
+)
 
 SECRET_KEY = "09d25e094faa6ca2556c818166b7a9563b93f7099f6f0f4caa6cf63b88e8d3e7"
 ALGORITHM = "HS256"
@@ -93,6 +96,7 @@ _directory_structure_repo = SqlAlchemyDirectoryRepository()
 _file_storage = GCPFileStorage()
 _metrics = LoggingMetricsService()
 _download_task_queue = CeleryDownloadTaskQueue()
+_translation_task_queue = CeleryTranslationTaskQueue()
 
 
 def get_user_repositories(user: User) -> tuple[
@@ -152,3 +156,7 @@ def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> User:
 
 def get_download_task_port() -> CeleryDownloadTaskQueue:
     return _download_task_queue
+
+
+def get_translation_task_port() -> CeleryTranslationTaskQueue:
+    return _translation_task_queue

--- a/src/codebase_to_llm/interface/fastapi/schemas.py
+++ b/src/codebase_to_llm/interface/fastapi/schemas.py
@@ -164,6 +164,12 @@ class YouTubeDownloadRequest(BaseModel):
     name: str
 
 
+class VideoTranslationRequest(BaseModel):
+    file_id: str | None = None
+    youtube_url: str | None = None
+    target_language: str = "en"
+
+
 class TaskStatusResponse(BaseModel):
     status: str
     file_id: str | None = None

--- a/src/codebase_to_llm/interface/fastapi/schemas.py
+++ b/src/codebase_to_llm/interface/fastapi/schemas.py
@@ -165,9 +165,9 @@ class YouTubeDownloadRequest(BaseModel):
 
 
 class VideoTranslationRequest(BaseModel):
-    file_id: str | None = None
-    youtube_url: str | None = None
+    file_id: str
     target_language: str = "en"
+    output_filename: str = "translated.mp4"
 
 
 class TaskStatusResponse(BaseModel):

--- a/src/codebase_to_llm/interface/fastapi/translations.py
+++ b/src/codebase_to_llm/interface/fastapi/translations.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from codebase_to_llm.application.ports import TranslationTaskPort
+from codebase_to_llm.application.uc_translate_video import (
+    enqueue_video_translation,
+    get_translation_status,
+)
+from codebase_to_llm.domain.user import User
+from .dependencies import get_translation_task_port, get_current_user
+from .schemas import TaskStatusResponse, VideoTranslationRequest
+
+router = APIRouter(prefix="/translations", tags=["translations"])
+
+
+@router.post("/")
+def request_video_translation(
+    request: VideoTranslationRequest,
+    current_user: User = Depends(get_current_user),
+    task_port: TranslationTaskPort = Depends(get_translation_task_port),
+) -> dict[str, str]:
+    if request.file_id is None and request.youtube_url is None:
+        raise HTTPException(
+            status_code=400, detail="Either file_id or youtube_url must be provided"
+        )
+    user_id = current_user.id().value()
+    result = enqueue_video_translation(
+        request.file_id,
+        request.youtube_url,
+        request.target_language,
+        user_id,
+        task_port,
+    )
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    task_id = result.ok()
+    assert task_id is not None
+    return {"task_id": task_id}
+
+
+@router.get("/{task_id}", response_model=TaskStatusResponse)
+def check_translation_task(
+    task_id: str, task_port: TranslationTaskPort = Depends(get_translation_task_port)
+) -> TaskStatusResponse:
+    result = get_translation_status(task_id, task_port)
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    data = result.ok()
+    assert data is not None
+    status, file_id = data
+    return TaskStatusResponse(status=status, file_id=file_id)

--- a/src/codebase_to_llm/interface/fastapi/translations.py
+++ b/src/codebase_to_llm/interface/fastapi/translations.py
@@ -20,16 +20,12 @@ def request_video_translation(
     current_user: User = Depends(get_current_user),
     task_port: TranslationTaskPort = Depends(get_translation_task_port),
 ) -> dict[str, str]:
-    if request.file_id is None and request.youtube_url is None:
-        raise HTTPException(
-            status_code=400, detail="Either file_id or youtube_url must be provided"
-        )
     user_id = current_user.id().value()
     result = enqueue_video_translation(
         request.file_id,
-        request.youtube_url,
         request.target_language,
         user_id,
+        request.output_filename,
         task_port,
     )
     if result.is_err():


### PR DESCRIPTION
## Summary
- add TranslationTaskPort, use case, and Celery translation queue to handle long-running subtitle translations
- expose translation queue through FastAPI with new routes and schemas

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black ./`


------
https://chatgpt.com/codex/tasks/task_e_68a4726870908332a90dde0ff0a3a20c