### PR TITLE
feat: async burn ASS subtitles via Celery

### DIFF
--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -329,6 +329,18 @@ class AddSubtitleTaskPort(Protocol):
     ) -> Result[tuple[str, str | None, str | None], str]: ...  # pragma: no cover
 
 
+class BurnAssTaskPort(Protocol):
+    """Port for long-running burn ASS subtitle tasks."""
+
+    def enqueue_burn_ass(
+        self, video_file_id: str, output_filename: str, owner_id: str
+    ) -> Result[str, str]: ...  # pragma: no cover
+
+    def get_task_status(
+        self, task_id: str
+    ) -> Result[tuple[str, str | None], str]: ...  # pragma: no cover
+
+
 class BurnAssSubtitlePort(Protocol):
     """Port for burning ASS subtitles into MKV videos."""
 

--- a/src/codebase_to_llm/application/uc_burn_ass_to_video.py
+++ b/src/codebase_to_llm/application/uc_burn_ass_to_video.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import BurnAssTaskPort
+from codebase_to_llm.domain.result import Result
+
+
+def enqueue_burn_ass_subtitle(
+    video_file_id: str,
+    output_filename: str,
+    owner_id: str,
+    task_port: BurnAssTaskPort,
+) -> Result[str, str]:
+    return task_port.enqueue_burn_ass(video_file_id, output_filename, owner_id)
+
+
+def get_burn_ass_status(
+    task_id: str, task_port: BurnAssTaskPort
+) -> Result[tuple[str, str | None], str]:
+    return task_port.get_task_status(task_id)

--- a/src/codebase_to_llm/infrastructure/celery_app.py
+++ b/src/codebase_to_llm/infrastructure/celery_app.py
@@ -27,6 +27,7 @@ try:
     import codebase_to_llm.infrastructure.celery_add_subtitle_queue  # noqa: F401
     import codebase_to_llm.infrastructure.celery_key_insights_queue  # noqa: F401
     import codebase_to_llm.infrastructure.celery_video_summary_queue  # noqa: F401
+    import codebase_to_llm.infrastructure.celery_burn_ass_queue  # noqa: F401
 except ImportError as e:
     # Log the error but don't fail - some tasks might not be available in all environments
     import logging

--- a/src/codebase_to_llm/infrastructure/celery_burn_ass_queue.py
+++ b/src/codebase_to_llm/infrastructure/celery_burn_ass_queue.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import uuid
+from typing_extensions import final
+
+from codebase_to_llm.application.ports import BurnAssTaskPort
+from codebase_to_llm.application.uc_add_file import AddFileUseCase
+from codebase_to_llm.application import uc_get_ass_file_by_video_id
+from codebase_to_llm.domain.result import Err, Ok, Result
+from codebase_to_llm.domain.stored_file import StoredFileId
+from codebase_to_llm.infrastructure.gcp_file_storage import GCPFileStorage
+from codebase_to_llm.infrastructure.sqlalchemy_file_repository import (
+    SqlAlchemyFileRepository,
+)
+from codebase_to_llm.infrastructure.sqlalchemy_video_subtitle_repository import (
+    SqlAlchemyVideoSubtitleRepository,
+)
+from codebase_to_llm.infrastructure.ffmpeg_burn_ass_subtitle import (
+    FFMPEGBurnAssSubtitle,
+)
+from codebase_to_llm.infrastructure.celery_app import celery_app
+
+
+def _load_video_from_file_id(file_id: str) -> Result[bytes, str]:
+    file_repo = SqlAlchemyFileRepository()
+    storage = GCPFileStorage()
+    id_res = StoredFileId.try_create(file_id)
+    if id_res.is_err():
+        return Err(id_res.err() or "Invalid file id")
+    stored_id = id_res.ok()
+    assert stored_id is not None
+    file_res = file_repo.get(stored_id)
+    if file_res.is_err():
+        return Err(file_res.err() or "File not found")
+    stored_file = file_res.ok()
+    assert stored_file is not None
+    content_res = storage.load(stored_file)
+    if content_res.is_err():
+        return Err(content_res.err() or "Unable to load file content")
+    data = content_res.ok()
+    assert data is not None
+    return Ok(data)
+
+
+@celery_app.task(name="burn_ass_subtitle")
+def burn_ass_subtitle_task(
+    video_file_id: str, output_filename: str, owner_id: str
+) -> str:  # pragma: no cover - worker
+    load_res = _load_video_from_file_id(video_file_id)
+    if load_res.is_err():  # pragma: no cover - worker
+        raise Exception(load_res.err() or "Failed to load video")
+    video_bytes = load_res.ok()
+    assert video_bytes is not None
+
+    video_subtitle_repo = SqlAlchemyVideoSubtitleRepository()
+    file_repo = SqlAlchemyFileRepository()
+    storage = GCPFileStorage()
+    subtitle_res = uc_get_ass_file_by_video_id.execute(
+        video_file_id, video_subtitle_repo, file_repo, storage
+    )
+    if subtitle_res.is_err():  # pragma: no cover - worker
+        raise Exception(subtitle_res.err() or "Subtitle retrieval failed")
+    subtitle_data = subtitle_res.ok()
+    assert subtitle_data is not None
+    _, subtitle_content = subtitle_data
+    subtitle_bytes = subtitle_content.encode("utf-8")
+
+    burner = FFMPEGBurnAssSubtitle()
+    burn_res = burner.burn_ass_subtitle(video_bytes, subtitle_bytes)
+    if burn_res.is_err():  # pragma: no cover - worker
+        raise Exception(burn_res.err() or "Burn failed")
+    output_bytes = burn_res.ok()
+    assert output_bytes is not None
+
+    new_file_id = str(uuid.uuid4())
+    add_file_use_case = AddFileUseCase(file_repo, storage)
+    add_res = add_file_use_case.execute(
+        id_value=new_file_id,
+        owner_id_value=owner_id,
+        name=output_filename,
+        content=output_bytes,
+        directory_id_value=None,
+    )
+    if add_res.is_err():  # pragma: no cover - worker
+        raise Exception(add_res.err() or "Failed to save file")
+    return new_file_id
+
+
+@final
+class CeleryBurnAssTaskQueue(BurnAssTaskPort):
+    """Celery-backed task queue for burning ASS subtitles."""
+
+    __slots__ = ()
+
+    def enqueue_burn_ass(
+        self, video_file_id: str, output_filename: str, owner_id: str
+    ) -> Result[str, str]:
+        try:
+            task = burn_ass_subtitle_task.delay(
+                video_file_id, output_filename, owner_id
+            )
+            return Ok(task.id)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+
+    def get_task_status(self, task_id: str) -> Result[tuple[str, str | None], str]:
+        try:
+            async_result = celery_app.AsyncResult(task_id)
+            status = async_result.status
+            if async_result.successful():
+                file_id = str(async_result.get())
+                return Ok((status, file_id))
+            return Ok((status, None))
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))

--- a/src/codebase_to_llm/interface/fastapi/burn_ass.py
+++ b/src/codebase_to_llm/interface/fastapi/burn_ass.py
@@ -1,29 +1,45 @@
 from __future__ import annotations
 
-import base64
 from fastapi import APIRouter, Depends, HTTPException
 
-from codebase_to_llm.application.ports import BurnAssSubtitlePort
-from codebase_to_llm.application import uc_burn_ass_subtitle
+from codebase_to_llm.application.ports import BurnAssTaskPort
+from codebase_to_llm.application.uc_burn_ass_to_video import (
+    enqueue_burn_ass_subtitle,
+    get_burn_ass_status,
+)
 from codebase_to_llm.domain.user import User
-from .dependencies import get_burn_ass_port, get_current_user
-from .schemas import BurnAssSubtitleRequest
+from .dependencies import get_burn_ass_task_port, get_current_user
+from .schemas import BurnAssRequest, TaskStatusResponse
 
 router = APIRouter(prefix="/burn_ass", tags=["burn_ass"])
 
 
-@router.post("/", summary="Burn ASS subtitle into MKV and convert to MP4")
-def burn_subtitle(
-    request: BurnAssSubtitleRequest,
+@router.post("/video/{video_file_id}")
+def request_burn_ass(
+    video_file_id: str,
+    request: BurnAssRequest,
     current_user: User = Depends(get_current_user),
-    port: BurnAssSubtitlePort = Depends(get_burn_ass_port),
+    task_port: BurnAssTaskPort = Depends(get_burn_ass_task_port),
 ) -> dict[str, str]:
-    video_bytes = base64.b64decode(request.video_content)
-    subtitle_bytes = base64.b64decode(request.subtitle_content)
-    result = uc_burn_ass_subtitle.execute(video_bytes, subtitle_bytes, port)
+    owner_id = current_user.id().value()
+    result = enqueue_burn_ass_subtitle(
+        video_file_id, request.output_filename, owner_id, task_port
+    )
     if result.is_err():
         raise HTTPException(status_code=400, detail=result.err())
-    output = result.ok()
-    assert output is not None
-    encoded = base64.b64encode(output).decode("utf-8")
-    return {"content": encoded}
+    task_id = result.ok()
+    assert task_id is not None
+    return {"task_id": task_id}
+
+
+@router.get("/{task_id}", response_model=TaskStatusResponse)
+def check_burn_ass_task(
+    task_id: str, task_port: BurnAssTaskPort = Depends(get_burn_ass_task_port)
+) -> TaskStatusResponse:
+    result = get_burn_ass_status(task_id, task_port)
+    if result.is_err():
+        raise HTTPException(status_code=400, detail=result.err())
+    data = result.ok()
+    assert data is not None
+    status, file_id = data
+    return TaskStatusResponse(status=status, file_id=file_id)

--- a/src/codebase_to_llm/interface/fastapi/dependencies.py
+++ b/src/codebase_to_llm/interface/fastapi/dependencies.py
@@ -73,8 +73,8 @@ from codebase_to_llm.infrastructure.sqlalchemy_video_summary_repository import (
 from codebase_to_llm.infrastructure.sqlalchemy_video_subtitle_repository import (
     SqlAlchemyVideoSubtitleRepository,
 )
-from codebase_to_llm.infrastructure.ffmpeg_burn_ass_subtitle import (
-    FFMPEGBurnAssSubtitle,
+from codebase_to_llm.infrastructure.celery_burn_ass_queue import (
+    CeleryBurnAssTaskQueue,
 )
 
 SECRET_KEY = "09d25e094faa6ca2556c818166b7a9563b93f7099f6f0f4caa6cf63b88e8d3e7"
@@ -118,7 +118,7 @@ _add_subtitles_task_queue = CeleryAddSubtitleTaskQueue()
 _key_insights_task_queue = CeleryKeyInsightsTaskQueue()
 _summary_task_queue = CeleryVideoSummaryTaskQueue()
 _video_subtitle_repo = SqlAlchemyVideoSubtitleRepository()
-_burn_ass_port = FFMPEGBurnAssSubtitle()
+_burn_ass_task_queue = CeleryBurnAssTaskQueue()
 
 
 def get_user_repositories(user: User) -> tuple[
@@ -204,8 +204,8 @@ def get_video_subtitle_repo() -> SqlAlchemyVideoSubtitleRepository:
     return _video_subtitle_repo
 
 
-def get_burn_ass_port() -> FFMPEGBurnAssSubtitle:
-    return _burn_ass_port
+def get_burn_ass_task_port() -> CeleryBurnAssTaskQueue:
+    return _burn_ass_task_queue
 
 
 def get_file_repo() -> SqlAlchemyFileRepository:

--- a/src/codebase_to_llm/interface/fastapi/schemas.py
+++ b/src/codebase_to_llm/interface/fastapi/schemas.py
@@ -217,9 +217,8 @@ class VideoSubtitleResponse(BaseModel):
     subtitle_file_id: str
 
 
-class BurnAssSubtitleRequest(BaseModel):
-    video_content: str
-    subtitle_content: str
+class BurnAssRequest(BaseModel):
+    output_filename: str
 
 
 class Timestamp(BaseModel):


### PR DESCRIPTION
## Summary
- add Celery task and port for burning ASS subtitles into videos
- expose POST /burn_ass/video/{video_file_id} to enqueue burns
- wire up Celery queue and request schema

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black ./`


------
https://chatgpt.com/codex/tasks/task_e_68af77a8461483328fdac616237c75a1