### PR TITLE
Add update and delete endpoints for ASS subtitles

### DIFF
--- a/src/codebase_to_llm/application/uc_delete_ass_file_by_video_id.py
+++ b/src/codebase_to_llm/application/uc_delete_ass_file_by_video_id.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import (
+    VideoSubtitleRepositoryPort,
+    FileRepositoryPort,
+    FileStoragePort,
+)
+from codebase_to_llm.domain.stored_file import StoredFileId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+def execute(
+    video_file_id_value: str,
+    video_subtitle_repo: VideoSubtitleRepositoryPort,
+    file_repo: FileRepositoryPort,
+    file_storage: FileStoragePort,
+) -> Result[str, str]:
+    """Delete the ASS subtitle file and its association for a given video file."""
+    video_file_id_res = StoredFileId.try_create(video_file_id_value)
+    if video_file_id_res.is_err():
+        return Err(video_file_id_res.err() or "Invalid video file id")
+    video_file_id = video_file_id_res.ok()
+    assert video_file_id is not None
+
+    association_res = video_subtitle_repo.get_by_video_file_id(video_file_id)
+    if association_res.is_err():
+        return Err(association_res.err() or "No subtitle found for this video")
+    association = association_res.ok()
+    assert association is not None
+
+    subtitle_file_id = association.subtitle_file_id()
+    subtitle_file_res = file_repo.get(subtitle_file_id)
+    if subtitle_file_res.is_err():
+        return Err(subtitle_file_res.err() or "Subtitle file not found")
+    subtitle_file = subtitle_file_res.ok()
+    assert subtitle_file is not None
+
+    delete_storage_res = file_storage.delete(subtitle_file)
+    if delete_storage_res.is_err():
+        return Err(delete_storage_res.err() or "Failed to delete subtitle content")
+
+    remove_file_res = file_repo.remove(subtitle_file_id)
+    if remove_file_res.is_err():
+        return Err(remove_file_res.err() or "Failed to remove subtitle file")
+
+    remove_assoc_res = video_subtitle_repo.remove(association.id())
+    if remove_assoc_res.is_err():
+        return Err(remove_assoc_res.err() or "Failed to remove subtitle association")
+
+    return Ok(subtitle_file_id.value())

--- a/src/codebase_to_llm/application/uc_update_ass_file_by_video_id.py
+++ b/src/codebase_to_llm/application/uc_update_ass_file_by_video_id.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from codebase_to_llm.application.ports import (
+    VideoSubtitleRepositoryPort,
+    FileRepositoryPort,
+    FileStoragePort,
+)
+from codebase_to_llm.domain.stored_file import StoredFileId
+from codebase_to_llm.domain.result import Result, Ok, Err
+
+
+def execute(
+    video_file_id_value: str,
+    new_content: str,
+    video_subtitle_repo: VideoSubtitleRepositoryPort,
+    file_repo: FileRepositoryPort,
+    file_storage: FileStoragePort,
+) -> Result[str, str]:
+    """Replace the ASS subtitle content for a given video file ID."""
+    video_file_id_res = StoredFileId.try_create(video_file_id_value)
+    if video_file_id_res.is_err():
+        return Err(video_file_id_res.err() or "Invalid video file id")
+    video_file_id = video_file_id_res.ok()
+    assert video_file_id is not None
+
+    association_res = video_subtitle_repo.get_by_video_file_id(video_file_id)
+    if association_res.is_err():
+        return Err(association_res.err() or "No subtitle found for this video")
+    association = association_res.ok()
+    assert association is not None
+
+    subtitle_file_id = association.subtitle_file_id()
+    subtitle_file_res = file_repo.get(subtitle_file_id)
+    if subtitle_file_res.is_err():
+        return Err(subtitle_file_res.err() or "Subtitle file not found")
+    subtitle_file = subtitle_file_res.ok()
+    assert subtitle_file is not None
+
+    save_res = file_storage.save(subtitle_file, new_content.encode("utf-8"))
+    if save_res.is_err():
+        return Err(save_res.err() or "Failed to save subtitle content")
+
+    return Ok(subtitle_file_id.value())

--- a/src/codebase_to_llm/interface/fastapi/schemas.py
+++ b/src/codebase_to_llm/interface/fastapi/schemas.py
@@ -299,3 +299,7 @@ class VideoSummaryResponse(BaseModel):
 class AssFileResponse(BaseModel):
     subtitle_file_id: str
     content: str
+
+
+class AssFileUpdateRequest(BaseModel):
+    content: str

--- a/tests/test_uc_update_and_delete_ass_file.py
+++ b/tests/test_uc_update_and_delete_ass_file.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from codebase_to_llm.application import (
+    uc_update_ass_file_by_video_id,
+    uc_delete_ass_file_by_video_id,
+)
+from codebase_to_llm.application.ports import (
+    VideoSubtitleRepositoryPort,
+    FileRepositoryPort,
+    FileStoragePort,
+)
+from codebase_to_llm.domain.user import UserId
+from codebase_to_llm.domain.stored_file import StoredFile, StoredFileId
+from codebase_to_llm.domain.video_subtitle import VideoSubtitle
+from codebase_to_llm.domain.result import Ok, Err
+
+
+class InMemoryFileRepo(FileRepositoryPort):
+    def __init__(self, files: dict[str, StoredFile]) -> None:
+        self._files = files
+
+    def add(self, file: StoredFile):  # pragma: no cover - unused
+        return Ok(None)
+
+    def get(self, file_id: StoredFileId):
+        file = self._files.get(file_id.value())
+        if file is None:
+            return Err("not found")
+        return Ok(file)
+
+    def update(self, file: StoredFile):  # pragma: no cover - unused
+        self._files[file.id().value()] = file
+        return Ok(None)
+
+    def remove(self, file_id: StoredFileId):
+        self._files.pop(file_id.value(), None)
+        return Ok(None)
+
+    def list_for_user(self, owner_id: UserId):  # pragma: no cover - unused
+        return Ok(list(self._files.values()))
+
+
+class InMemoryFileStorage(FileStoragePort):
+    def __init__(self, contents: dict[str, bytes]) -> None:
+        self._contents = contents
+
+    def save(self, file: StoredFile, content: bytes):
+        self._contents[file.id().value()] = content
+        return Ok(None)
+
+    def load(self, file: StoredFile):  # pragma: no cover - unused
+        data = self._contents.get(file.id().value())
+        if data is None:
+            return Err("not found")
+        return Ok(data)
+
+    def delete(self, file: StoredFile):
+        self._contents.pop(file.id().value(), None)
+        return Ok(None)
+
+
+class InMemoryVideoSubtitleRepo(VideoSubtitleRepositoryPort):
+    def __init__(self, association: VideoSubtitle) -> None:
+        self._assoc = association
+
+    def add(self, association: VideoSubtitle):  # pragma: no cover - unused
+        self._assoc = association
+        return Ok(None)
+
+    def get(self, association_id):  # pragma: no cover - unused
+        return Ok(self._assoc)
+
+    def get_by_video_file_id(self, video_file_id):
+        if self._assoc.video_file_id().value() != video_file_id.value():
+            return Err("not found")
+        return Ok(self._assoc)
+
+    def update(self, association: VideoSubtitle):  # pragma: no cover - unused
+        self._assoc = association
+        return Ok(None)
+
+    def remove(self, association_id):
+        self._assoc = None  # type: ignore[assignment]
+        return Ok(None)
+
+
+def test_update_and_delete_ass_file() -> None:
+    owner = UserId.try_create("u1").ok()
+    assert owner is not None
+    video_id = StoredFileId.try_create("video").ok()
+    subtitle_id = StoredFileId.try_create("sub").ok()
+    assert video_id is not None and subtitle_id is not None
+    stored_file = StoredFile.try_create("sub", owner, "s.ass").ok()
+    assert stored_file is not None
+    association = VideoSubtitle.try_create("assoc", video_id, subtitle_id).ok()
+    assert association is not None
+
+    file_repo = InMemoryFileRepo({"sub": stored_file})
+    storage = InMemoryFileStorage({"sub": b"old"})
+    assoc_repo = InMemoryVideoSubtitleRepo(association)
+
+    update_res = uc_update_ass_file_by_video_id.execute(
+        "video", "new content", assoc_repo, file_repo, storage
+    )
+    assert update_res.is_ok()
+    assert storage._contents["sub"] == b"new content"
+
+    delete_res = uc_delete_ass_file_by_video_id.execute(
+        "video", assoc_repo, file_repo, storage
+    )
+    assert delete_res.is_ok()
+    assert "sub" not in storage._contents
+    assert file_repo._files == {}


### PR DESCRIPTION
## Summary
- allow ASS subtitle content replacement via `/video_subtitles/video/{video_file_id}/ass`
- support removing subtitle files and associations
- cover update and deletion use cases with tests

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black ./`


------
https://chatgpt.com/codex/tasks/task_e_68af73a8badc8332a48d2e435df615cf