### PR TITLE
Enforce subtitle ownership when retrieving ASS by video ID

### DIFF
--- a/src/codebase_to_llm/application/uc_get_ass_file_by_video_id.py
+++ b/src/codebase_to_llm/application/uc_get_ass_file_by_video_id.py
@@ -6,11 +6,13 @@ from codebase_to_llm.application.ports import (
     FileStoragePort,
 )
 from codebase_to_llm.domain.stored_file import StoredFileId
+from codebase_to_llm.domain.user import UserId
 from codebase_to_llm.domain.result import Result, Ok, Err
 
 
 def execute(
     video_file_id_value: str,
+    owner_id_value: str,
     video_subtitle_repo: VideoSubtitleRepositoryPort,
     file_repo: FileRepositoryPort,
     file_storage: FileStoragePort,
@@ -20,12 +22,27 @@ def execute(
     Returns:
         Result containing tuple of (subtitle_file_id, subtitle_content) or error message
     """
-    # Validate and create video file ID
+    # Validate owner and video file ID
+    owner_res = UserId.try_create(owner_id_value)
+    if owner_res.is_err():
+        return Err(owner_res.err() or "Invalid owner id")
+    owner_id = owner_res.ok()
+    assert owner_id is not None
+
     video_file_id_res = StoredFileId.try_create(video_file_id_value)
     if video_file_id_res.is_err():
         return Err(video_file_id_res.err() or "Invalid video file id")
     video_file_id = video_file_id_res.ok()
     assert video_file_id is not None
+
+    # Ensure the video file belongs to the owner
+    video_file_res = file_repo.get(video_file_id)
+    if video_file_res.is_err():
+        return Err(video_file_res.err() or "Video file not found")
+    video_file = video_file_res.ok()
+    assert video_file is not None
+    if video_file.owner_id().value() != owner_id.value():
+        return Err("Access denied")
 
     # Find the video-subtitle association
     association_res = video_subtitle_repo.get_by_video_file_id(video_file_id)
@@ -41,6 +58,8 @@ def execute(
         return Err(subtitle_file_res.err() or "Subtitle file not found")
     subtitle_file = subtitle_file_res.ok()
     assert subtitle_file is not None
+    if subtitle_file.owner_id().value() != owner_id.value():
+        return Err("Access denied")
 
     # Load the subtitle file content
     content_res = file_storage.load(subtitle_file)

--- a/src/codebase_to_llm/interface/fastapi/video_subtitles.py
+++ b/src/codebase_to_llm/interface/fastapi/video_subtitles.py
@@ -30,7 +30,11 @@ def get_ass_file_by_video_id(
 ) -> AssFileResponse:
     """Get the ASS subtitle file ID and content for a given video file ID."""
     result = uc_get_ass_file_by_video_id.execute(
-        video_file_id, video_subtitle_repo, file_repo, file_storage
+        video_file_id,
+        current_user.id().value(),
+        video_subtitle_repo,
+        file_repo,
+        file_storage,
     )
     if result.is_err():
         raise HTTPException(status_code=404, detail=result.err())


### PR DESCRIPTION
## Summary
- require user ownership in `uc_get_ass_file_by_video_id`
- pass current user to subtitle retrieval endpoint

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black src/codebase_to_llm/application/uc_get_ass_file_by_video_id.py src/codebase_to_llm/interface/fastapi/video_subtitles.py`


------
https://chatgpt.com/codex/tasks/task_e_68b155f3df3483328aef95f1e23149ed