### PR TITLE
feat: auto-generate titles for key insights and summaries

### DIFF
--- a/features/steps/video_key_insights_steps.py
+++ b/features/steps/video_key_insights_steps.py
@@ -413,8 +413,11 @@ def step_create_video_key_insights_from_task_result(context):
             }
         )
 
+    title = context.completed_task_data.get(
+        "title", f"YouTube Video Key Insights - {context.youtube_video_url}"
+    )
     video_key_insights_data = {
-        "title": f"YouTube Video Key Insights - {context.youtube_video_url}",
+        "title": title,
         "key_insights": converted_insights,
     }
     context.test_video_key_insights = video_key_insights_data

--- a/features/steps/video_summary_steps.py
+++ b/features/steps/video_summary_steps.py
@@ -280,8 +280,11 @@ def step_video_summary_should_contain_multiple_segments(context):
 @when("I create a video summary from the task result")
 def step_create_video_summary_from_task_result(context):
     # Create a video summary using the segments from the completed task
+    title = context.completed_task_data.get(
+        "title", f"YouTube Video Summary - {context.youtube_video_url}"
+    )
     video_summary_data = {
-        "title": f"YouTube Video Summary - {context.youtube_video_url}",
+        "title": title,
         "segments": context.task_segments,
     }
 

--- a/src/codebase_to_llm/application/ports.py
+++ b/src/codebase_to_llm/application/ports.py
@@ -351,7 +351,7 @@ class KeyInsightsTaskPort(Protocol):
 
     def get_task_status(
         self, task_id: str
-    ) -> Result[tuple[str, list[dict[str, str]] | None], str]: ...  # pragma: no cover
+    ) -> Result[tuple[str, dict[str, object] | None], str]: ...  # pragma: no cover
 
 
 class SummaryTaskPort(Protocol):
@@ -363,9 +363,7 @@ class SummaryTaskPort(Protocol):
 
     def get_task_status(
         self, task_id: str
-    ) -> Result[
-        tuple[str, list[dict[str, object]] | None], str
-    ]: ...  # pragma: no cover
+    ) -> Result[tuple[str, dict[str, object] | None], str]: ...  # pragma: no cover
 
 
 class VideoKeyInsightsRepositoryPort(Protocol):

--- a/src/codebase_to_llm/application/uc_key_insights_task.py
+++ b/src/codebase_to_llm/application/uc_key_insights_task.py
@@ -19,5 +19,5 @@ def enqueue_key_insights_extraction(
 
 def get_key_insights_status(
     task_id: str, task_port: KeyInsightsTaskPort
-) -> Result[tuple[str, list[dict[str, str]] | None], str]:
+) -> Result[tuple[str, dict[str, object] | None], str]:
     return task_port.get_task_status(task_id)

--- a/src/codebase_to_llm/application/uc_video_summary_task.py
+++ b/src/codebase_to_llm/application/uc_video_summary_task.py
@@ -16,5 +16,5 @@ def enqueue_video_summary_generation(
 
 def get_video_summary_status(
     task_id: str, task_port: SummaryTaskPort
-) -> Result[tuple[str, list[dict[str, object]] | None], str]:
+) -> Result[tuple[str, dict[str, object] | None], str]:
     return task_port.get_task_status(task_id)

--- a/src/codebase_to_llm/interface/fastapi/schemas.py
+++ b/src/codebase_to_llm/interface/fastapi/schemas.py
@@ -147,6 +147,7 @@ class KeyInsightResponse(BaseModel):
 
 class KeyInsightsTaskStatusResponse(BaseModel):
     status: str
+    title: str | None = None
     insights: list[KeyInsightResponse] | None = None
 
 
@@ -268,6 +269,7 @@ class SummarySegmentResponse(BaseModel):
 
 class SummaryTaskStatusResponse(BaseModel):
     status: str
+    title: str | None = None
     segments: list[SummarySegmentResponse] | None = None
 
 


### PR DESCRIPTION
## Summary
- generate and return titles in key insight extraction responses
- include model-generated title when extracting video summaries
- expose title in task status APIs and use it when persisting results

## Testing
- `uv run pytest`
- `uv run ruff check ./src/`
- `uv run mypy ./src/`
- `uv run black ./`


------
https://chatgpt.com/codex/tasks/task_e_68b0c54e7ef08332a9e2a5221cb90bce